### PR TITLE
Touch up documentation and TODO list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,57 @@
-Asynco de Coggo
-===============
+Coggo
+=====
 
-Minimalistic rewrite of Cog, the fun parts.
+Alt-core [Cog] runtime implementation.
 
-* Python
-  * Zero dependency
-  * Single file data class only API surface
-  * Async by default, single process runner
-  * File based input & output
-  * POSIX signal IPC with HTTP parent
-* Go
-  * HTTP server
-  * Logging
+The original [Cog] seeks to be a great developer tool and also an arguably great
+production runtime. Coggo is focused on being a fantastic production runtime _only_.
 
-TODO:
-* Python
-  * Test all Python versions
-* Go
-  * Output file encoding and upload
-  * Webhook interval
-  * E2E tests
-* Build
-  * Go binary
-  * Python source tree
-  * Install both in monobase build.sh
+How is Coggo formed?
+
+```mermaid
+sequenceDiagram
+    r8->>coggo-server: HTTP
+    activate coggo-server
+    coggo-server->>cog.internal.file_runner: File write
+    activate cog.internal.file_runner
+    cog.internal.file_runner-->>coggo-server: SIGUSR1
+    cog.internal.file_runner-->>coggo-server: SIGHUP
+    coggo-server->>cog.internal.file_runner: File read
+    deactivate cog.internal.file_runner
+    coggo-server->>r8: HTTP
+    deactivate coggo-server
+```
+
+This sequence is simplified, but the rough idea is that the Replicate platform (`r8`)
+depends on `coggo-server` to provide an HTTP API in front of a `cog.internal.file_runner`
+that communicates via files and signals.
+
+## `coggo-server`
+
+Go-based HTTP server that known how to spawn and communicate with
+`cog.internal.file_runner`.
+
+## `cog.internal.file_runner`
+
+Python-based model runner with zero dependencies outside of the standard library.
+The same in-process API provided by [Cog] is avaaliable, e.g.:
+
+```python
+from cog import BasePredictor, Input
+
+class MyPredictor(BasePredictor):
+    def predict(self, n=Input(default="how many", ge=1, le=100)) -> str:
+        return "ok" * n
+```
+
+In addition to simple cases like the above, the runner is async by default and supports
+continuous batching.
+
+Communication with the `coggo-server` parent process is managed via input and output files
+and the following signals:
+
+- `SIGUSR1` model is ready
+- `SIGUSR2` model is busy
+- `SIGHUP` output is available
+
+[Cog]: <https://github.com/replicate/cog>

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,12 @@
+* Python
+  * Test all Python versions
+
+* Go
+  * Output file encoding and upload
+  * Webhook interval
+  * E2E tests
+
+* Build
+  * Go binary
+  * Python source tree
+  * Install both in monobase build.sh

--- a/cmd/coggo-server/main.go
+++ b/cmd/coggo-server/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/replicate/coggo/internal/util"
 )
 
-var logger = logging.New("cog-http-server")
+var logger = logging.New("coggo-server")
 
 type Config struct {
 	Host                  string `ff:"long: host, default: 0.0.0.0, usage: HTTP server host"`
@@ -43,12 +43,12 @@ func main() {
 	log := logger.Sugar()
 
 	var cfg Config
-	flags := ff.NewFlagSet("cog-http-server")
+	flags := ff.NewFlagSet("coggo-server")
 	must.Do(flags.AddStruct(&cfg))
 
 	cmd := &ff.Command{
-		Name:  "cog-http-server",
-		Usage: "cog-http-server [FLAGS]",
+		Name:  "coggo-server",
+		Usage: "coggo-server [FLAGS]",
 		Flags: flags,
 		Exec: func(ctx context.Context, args []string) error {
 			if err := cfg.Validate(); err != nil {
@@ -67,7 +67,7 @@ func main() {
 			}
 			workingDir := cfg.WorkingDir
 			if workingDir == "" {
-				workingDir = must.Get(os.MkdirTemp("", "cog-http-server-"))
+				workingDir = must.Get(os.MkdirTemp("", "coggo-server-"))
 			}
 			log.Infow("configuration", "working-dir", workingDir, "module-name", moduleName, "class-name", className)
 

--- a/script/coggo.sh
+++ b/script/coggo.sh
@@ -18,7 +18,7 @@ export PATH="$base_dir/python/.venv/bin:$PATH"
 export PYTHONPATH="$base_dir/python"
 rm -rf tmp
 mkdir -p tmp
-go run cmd/server/main.go \
+go run cmd/coggo-server/main.go \
     --working-dir tmp \
     --module-name "tests.runners.$module" \
     --class-name Predictor \


### PR DESCRIPTION
separating out a `TODO.md` ahead of breaking into issues, plus renaming the Go server to `coggo-server`.