### PR TITLE
Add pseudo-version to cog compat layer

### DIFF
--- a/python/coglet/_compat/cog.py
+++ b/python/coglet/_compat/cog.py
@@ -7,6 +7,9 @@ from coglet.api import (
     Secret,
 )
 
+__version__ = '0.11.3+coglet-compat'
+__version_tuple__ = (0, 11, 3, '', 'coglet-compat')
+
 __all__ = [
     'BaseModel',
     'BasePredictor',
@@ -14,4 +17,5 @@ __all__ = [
     'Input',
     'Path',
     'Secret',
+    '__version__',
 ]

--- a/python/coglet/_compat/cog.py
+++ b/python/coglet/_compat/cog.py
@@ -7,8 +7,8 @@ from coglet.api import (
     Secret,
 )
 
-__version__ = '0.11.3+coglet-compat'
-__version_tuple__ = (0, 11, 3, '', 'coglet-compat')
+__version__ = '0.0.8001+coglet'
+__version_tuple__ = (0, 0, 8001, '', 'coglet')
 
 __all__ = [
     'BaseModel',


### PR DESCRIPTION
so that `python -c 'import cog;print(cog.__version__)'` does not blow up and is arguably useful.