### PR TITLE
Test against legacy Cog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   check-go:
     name: Check Go
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
@@ -29,7 +29,7 @@ jobs:
 
   test-go:
     name: Test Go
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     strategy:
       fail-fast: false
     steps:
@@ -37,7 +37,21 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v3
+      - run: ./script/init.sh
       - run: ./script/test.sh go
+
+  test-go-legacy-cog:
+    name: Test Go with legacy Cog
+    runs-on: ubuntu-latest-4-cores
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v3
+      - run: ./script/init.sh
+      - run: ./script/test.sh go -legacy-cog
 
   build-python:
     name: Build & verify python package
@@ -83,4 +97,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v3
+      - run: ./script/init.sh
       - run: ./script/test.sh python

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -231,7 +231,8 @@ func (r *Runner) wait() {
 				pr.response.StartedAt = now
 			}
 			pr.response.CompletedAt = now
-			pr.response.Error = runnerLogs
+			pr.response.Logs += runnerLogs
+			pr.response.Error = "prediction failed"
 			pr.response.Status = PredictionFailed
 			pr.mu.Unlock()
 

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -43,22 +43,26 @@ func (pr *PendingPrediction) appendLogLine(line string) {
 
 func (pr *PendingPrediction) sendWebhook(event WebhookEvent) {
 	pr.mu.Lock()
-	if pr.request.Webhook == "" {
+	defer func() {
+		// Only async and iterator predict writes new response per output item with status = "processing"
+		// For blocking or non-iterator cases, set it here immediately after sending "starting" webhook
+		if pr.response.Status == PredictionStarting {
+			pr.response.Status = PredictionProcessing
+		}
 		pr.mu.Unlock()
+	}()
+	if pr.request.Webhook == "" {
 		return
 	}
 	if len(pr.request.WebhookEventsFilter) > 0 && !slices.Contains(pr.request.WebhookEventsFilter, event) {
-		pr.mu.Unlock()
 		return
 	}
 	if pr.response.Status == PredictionProcessing {
 		if time.Since(pr.lastUpdated) < 500*time.Millisecond {
-			pr.mu.Unlock()
 			return
 		}
 		pr.lastUpdated = time.Now()
 	}
-	pr.mu.Unlock()
 
 	log := logger.Sugar()
 	log.Infow("sending webhook", "url", pr.request.Webhook, "response", pr.response)
@@ -362,11 +366,6 @@ func (r *Runner) handleResponses() {
 		if pr.response.Status == PredictionStarting {
 			log.Infow("prediction started", "id", pr.request.Id, "status", pr.response.Status)
 			pr.sendWebhook(WebhookStart)
-			// Only async and iterator predict writes new response per output item with status = "processing"
-			// For blocking or non-iterator cases, set it here immediately after sending "starting" webhook
-			pr.mu.Lock()
-			pr.response.Status = PredictionProcessing
-			pr.mu.Unlock()
 		} else if pr.response.Status == PredictionProcessing {
 			log.Infow("prediction processing", "id", pr.request.Id, "status", pr.response.Status)
 			pr.sendWebhook(WebhookOutput)

--- a/internal/tests/async_prediction_test.go
+++ b/internal/tests/async_prediction_test.go
@@ -19,15 +19,29 @@ func TestAsyncPredictionSucceeded(t *testing.T) {
 
 	ct.AsyncPrediction(map[string]any{"i": 1, "s": "bar"})
 	wr := ct.WaitForWebhookResponses()
-	logs := ""
-	ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-	logs += "starting prediction\n"
-	ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-	logs += "prediction in progress 1/1\n"
-	ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-	logs += "completed prediction\n"
-	ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
-	ct.AssertResponse(wr[4], server.PredictionSucceeded, "*bar*", logs)
+	if *legacyCog {
+		assert.Len(t, wr, 3)
+		logs := ""
+		// Compat: legacy Cog sends no "starting" event
+		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
+		// Compat: legacy Cog buffers logging?
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, "*bar*", logs)
+		logs += "prediction in progress 1/1\n"
+		logs += "completed prediction\n"
+		ct.AssertResponse(wr[2], server.PredictionSucceeded, "*bar*", logs)
+	} else {
+		assert.Len(t, wr, 5)
+		logs := ""
+		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
+		logs += "prediction in progress 1/1\n"
+		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
+		logs += "completed prediction\n"
+		ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
+		ct.AssertResponse(wr[4], server.PredictionSucceeded, "*bar*", logs)
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -44,15 +58,29 @@ func TestAsyncPredictionWithIdSucceeded(t *testing.T) {
 
 	ct.AsyncPredictionWithId("p01", map[string]any{"i": 1, "s": "bar"})
 	wr := ct.WaitForWebhookResponses()
-	logs := ""
-	ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-	logs += "starting prediction\n"
-	ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-	logs += "prediction in progress 1/1\n"
-	ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-	logs += "completed prediction\n"
-	ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
-	ct.AssertResponse(wr[4], server.PredictionSucceeded, "*bar*", logs)
+	if *legacyCog {
+		assert.Len(t, wr, 3)
+		logs := ""
+		// Compat: legacy Cog sends no "starting" event
+		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
+		// Compat: legacy Cog buffers logging?
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, "*bar*", logs)
+		logs += "prediction in progress 1/1\n"
+		logs += "completed prediction\n"
+		ct.AssertResponse(wr[2], server.PredictionSucceeded, "*bar*", logs)
+	} else {
+		assert.Len(t, wr, 5)
+		logs := ""
+		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
+		logs += "prediction in progress 1/1\n"
+		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
+		logs += "completed prediction\n"
+		ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
+		ct.AssertResponse(wr[4], server.PredictionSucceeded, "*bar*", logs)
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -70,15 +98,38 @@ func TestAsyncPredictionFailure(t *testing.T) {
 
 	ct.AsyncPrediction(map[string]any{"i": 1, "s": "bar"})
 	wr := ct.WaitForWebhookResponses()
-	logs := ""
-	ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-	logs += "starting prediction\n"
-	ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-	logs += "prediction in progress 1/1\n"
-	ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-	logs += "prediction failed\n"
-	ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
-	ct.AssertResponse(wr[4], server.PredictionFailed, nil, logs)
+	if *legacyCog {
+		assert.Len(t, wr, 3)
+		logs := ""
+		// Compat: legacy Cog sends no "starting" event
+		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
+		assert.Equal(t, server.PredictionProcessing, wr[1].Status)
+		assert.Equal(t, nil, wr[1].Output)
+		// Compat: legacy Cog includes worker stacktrace
+		assert.Contains(t, wr[1].Logs, "Traceback")
+		// Compat: legacy Cog buffers logging?
+		logs += "starting prediction\n"
+		logs += "prediction in progress 1/1\n"
+		logs += "prediction failed\n"
+		assert.Equal(t, server.PredictionFailed, wr[2].Status)
+		assert.Equal(t, nil, wr[2].Output)
+		// Compat: legacy Cog includes worker stacktrace
+		assert.Contains(t, wr[2].Logs, "Traceback")
+		assert.Contains(t, wr[2].Logs, logs)
+		assert.Equal(t, "prediction failed", wr[2].Error)
+	} else {
+		assert.Len(t, wr, 5)
+		logs := ""
+		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
+		logs += "prediction in progress 1/1\n"
+		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
+		logs += "prediction failed\n"
+		ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
+		ct.AssertResponse(wr[4], server.PredictionFailed, nil, logs)
+		assert.Equal(t, "prediction failed", wr[4].Error)
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -97,17 +148,45 @@ func TestAsyncPredictionCrash(t *testing.T) {
 
 	ct.AsyncPrediction(map[string]any{"i": 1, "s": "bar"})
 	wr := ct.WaitForWebhookResponses()
-	logs := ""
-	ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-	logs += "starting prediction\n"
-	ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-	logs += "prediction in progress 1/1\n"
-	ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-	logs += "prediction crashed\n"
-	ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
-	ct.AssertResponse(wr[4], server.PredictionFailed, nil, logs)
-
-	assert.Equal(t, "DEFUNCT", ct.HealthCheck().Status)
+	if *legacyCog {
+		assert.Len(t, wr, 3)
+		logs := ""
+		// Compat: legacy Cog sends no "starting" event
+		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
+		assert.Equal(t, server.PredictionProcessing, wr[1].Status)
+		assert.Equal(t, nil, wr[1].Output)
+		// Compat: legacy Cog includes worker stacktrace
+		assert.Contains(t, wr[1].Logs, "Traceback")
+		// Compat: legacy Cog buffers logging?
+		logs += "starting prediction\n"
+		logs += "prediction in progress 1/1\n"
+		logs += "prediction crashed\n"
+		assert.Equal(t, server.PredictionFailed, wr[2].Status)
+		assert.Equal(t, nil, wr[2].Output)
+		// Compat: legacy Cog includes worker stacktrace
+		assert.Contains(t, wr[2].Logs, "Traceback")
+		assert.Contains(t, wr[2].Logs, logs)
+		// Compat: legacy Cog cannot handle worker crash
+		errMsg := "Prediction failed for an unknown reason. It might have run out of memory? (exitcode 1)"
+		assert.Equal(t, errMsg, wr[2].Error)
+		assert.Equal(t, "DEFUNCT", ct.HealthCheck().Status)
+	} else {
+		assert.Len(t, wr, 5)
+		logs := ""
+		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
+		logs += "prediction in progress 1/1\n"
+		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
+		logs += "prediction crashed\n"
+		ct.AssertResponse(wr[3], server.PredictionProcessing, nil, logs)
+		assert.Equal(t, server.PredictionFailed, wr[4].Status)
+		assert.Equal(t, nil, wr[4].Output)
+		assert.Contains(t, wr[4].Logs, logs)
+		assert.Contains(t, wr[4].Logs, "SystemExit: 1\n")
+		assert.Equal(t, "prediction failed", wr[4].Error)
+		assert.Equal(t, "DEFUNCT", ct.HealthCheck().Status)
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/async_predictor_test.go
+++ b/internal/tests/async_predictor_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAsyncPredictorSucceeded(t *testing.T) {
+	if *legacyCog {
+		t.SkipNow()
+	}
 	ct := NewCogTest(t, "async_sleep")
 	ct.StartWebhook()
 	assert.NoError(t, ct.Start())

--- a/internal/tests/async_predictor_test.go
+++ b/internal/tests/async_predictor_test.go
@@ -32,8 +32,8 @@ func TestAsyncPredictorSucceeded(t *testing.T) {
 			bazR = append(bazR, r)
 		}
 	}
-	assert.Equal(t, 5, len(barR))
-	assert.Equal(t, 6, len(bazR))
+	assert.Len(t, barR, 5)
+	assert.Len(t, bazR, 6)
 
 	barLogs := ""
 	ct.AssertResponse(barR[0], server.PredictionStarting, nil, barLogs)

--- a/internal/tests/cog_test.go
+++ b/internal/tests/cog_test.go
@@ -296,6 +296,7 @@ func (ct *CogTest) AsyncPredictionWithId(pid string, input map[string]any) strin
 
 func (ct *CogTest) asyncPrediction(method string, url string, req server.PredictionRequest) string {
 	ct.pending++
+	req.CreatedAt = util.NowIso()
 	req.Webhook = fmt.Sprintf("http://localhost:%d/webhook", ct.webhookPort)
 	data := bytes.NewReader(must.Get(json.Marshal(req)))
 	r := must.Get(http.NewRequest(method, url, data))

--- a/internal/tests/cog_test.go
+++ b/internal/tests/cog_test.go
@@ -310,7 +310,7 @@ func (ct *CogTest) asyncPrediction(method string, url string, req server.Predict
 }
 
 func (ct *CogTest) Shutdown() {
-	url := fmt.Sprintf("http://localhost:%d/shutdown", ct.serverPort)
+	url := ct.Url("/shutdown")
 	resp := must.Get(http.DefaultClient.Post(url, "", nil))
 	assert.Equal(ct.t, http.StatusOK, resp.StatusCode)
 }

--- a/internal/tests/cog_test.go
+++ b/internal/tests/cog_test.go
@@ -290,7 +290,7 @@ func (ct *CogTest) AsyncPredictionWithFilter(input map[string]any, filter []serv
 }
 
 func (ct *CogTest) AsyncPredictionWithId(pid string, input map[string]any) string {
-	req := server.PredictionRequest{Input: input}
+	req := server.PredictionRequest{Id: pid, Input: input}
 	return ct.asyncPrediction(http.MethodPut, ct.Url(fmt.Sprintf("/predictions/%s", pid)), req)
 }
 

--- a/internal/tests/cog_test.go
+++ b/internal/tests/cog_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/replicate/cog-runtime/internal/util"
+
 	"github.com/replicate/go/logging"
 
 	"github.com/replicate/go/must"
@@ -250,7 +252,7 @@ func (ct *CogTest) Prediction(input map[string]any) server.PredictionResponse {
 }
 
 func (ct *CogTest) PredictionWithId(pid string, input map[string]any) server.PredictionResponse {
-	req := server.PredictionRequest{Input: input}
+	req := server.PredictionRequest{Id: pid, Input: input}
 	return ct.prediction(http.MethodPut, ct.Url(fmt.Sprintf("/predictions/%s", pid)), req)
 }
 
@@ -263,6 +265,7 @@ func (ct *CogTest) PredictionWithUpload(input map[string]any) server.PredictionR
 }
 
 func (ct *CogTest) prediction(method string, url string, req server.PredictionRequest) server.PredictionResponse {
+	req.CreatedAt = util.NowIso()
 	data := bytes.NewReader(must.Get(json.Marshal(req)))
 	r := must.Get(http.NewRequest(method, url, data))
 	r.Header.Set("Content-Type", "application/json")

--- a/internal/tests/iterator_test.go
+++ b/internal/tests/iterator_test.go
@@ -9,36 +9,15 @@ import (
 )
 
 func TestPredictionIteratorSucceeded(t *testing.T) {
-	ct := NewCogTest(t, "iterator")
-	ct.StartWebhook()
-	assert.NoError(t, ct.Start())
-
-	hc := ct.WaitForSetup()
-	assert.Equal(t, server.StatusReady.String(), hc.Status)
-	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
-
-	ct.AsyncPrediction(map[string]any{"i": 2, "s": "bar"})
-	wr := ct.WaitForWebhookResponses()
-	logs := ""
-	ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-	logs += "starting prediction\n"
-	ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-	logs += "prediction in progress 1/2\n"
-	ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-	ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-	logs += "prediction in progress 2/2\n"
-	ct.AssertResponse(wr[4], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-	ct.AssertResponse(wr[5], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-	logs += "completed prediction\n"
-	ct.AssertResponse(wr[6], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-	ct.AssertResponse(wr[7], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
-
-	ct.Shutdown()
-	assert.NoError(t, ct.Cleanup())
+	testPredictionIteratorSucceeded(t, "iterator")
 }
 
 func TestPredictionConcatenateIteratorSucceeded(t *testing.T) {
-	ct := NewCogTest(t, "concat_iterator")
+	testPredictionIteratorSucceeded(t, "concat_iterator")
+}
+
+func testPredictionIteratorSucceeded(t *testing.T, module string) {
+	ct := NewCogTest(t, module)
 	ct.StartWebhook()
 	assert.NoError(t, ct.Start())
 
@@ -48,19 +27,36 @@ func TestPredictionConcatenateIteratorSucceeded(t *testing.T) {
 
 	ct.AsyncPrediction(map[string]any{"i": 2, "s": "bar"})
 	wr := ct.WaitForWebhookResponses()
-	logs := ""
-	ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-	logs += "starting prediction\n"
-	ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-	logs += "prediction in progress 1/2\n"
-	ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-	ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-	logs += "prediction in progress 2/2\n"
-	ct.AssertResponse(wr[4], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-	ct.AssertResponse(wr[5], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-	logs += "completed prediction\n"
-	ct.AssertResponse(wr[6], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-	ct.AssertResponse(wr[7], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
+	if *legacyCog {
+		assert.Len(t, wr, 5)
+		logs := ""
+		// Compat: legacy Cog sends no "starting" event
+		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
+		ct.AssertResponse(wr[1], server.PredictionProcessing, []any{"*bar-0*"}, logs)
+		ct.AssertResponse(wr[2], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
+		// Compat: legacy Cog buffers logging?
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
+		logs += "prediction in progress 1/2\n"
+		logs += "prediction in progress 2/2\n"
+		logs += "completed prediction\n"
+		ct.AssertResponse(wr[4], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
+	} else {
+		assert.Len(t, wr, 8)
+		logs := ""
+		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
+		logs += "starting prediction\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
+		logs += "prediction in progress 1/2\n"
+		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
+		ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*"}, logs)
+		logs += "prediction in progress 2/2\n"
+		ct.AssertResponse(wr[4], server.PredictionProcessing, []any{"*bar-0*"}, logs)
+		ct.AssertResponse(wr[5], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
+		logs += "completed prediction\n"
+		ct.AssertResponse(wr[6], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
+		ct.AssertResponse(wr[7], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/path_test.go
+++ b/internal/tests/path_test.go
@@ -16,6 +16,11 @@ func b64encode(s string) string {
 	return fmt.Sprintf("data:text/plain; charset=utf-8;base64,%s", b64)
 }
 
+func b64encodeLegacy(s string) string {
+	b64 := base64.StdEncoding.EncodeToString([]byte(s))
+	return fmt.Sprintf("data:text/plain;base64,%s", b64)
+}
+
 func TestPredictionPathSucceeded(t *testing.T) {
 	ct := NewCogTest(t, "path")
 	assert.NoError(t, ct.Start())
@@ -26,7 +31,12 @@ func TestPredictionPathSucceeded(t *testing.T) {
 
 	resp := ct.Prediction(map[string]any{"p": b64encode("bar")})
 	logs := "reading input file\nwriting output file\n"
-	ct.AssertResponse(resp, server.PredictionSucceeded, b64encode("*bar*"), logs)
+	if *legacyCog {
+		// Compat: different MIME type detection logic
+		ct.AssertResponse(resp, server.PredictionSucceeded, b64encodeLegacy("*bar*"), logs)
+	} else {
+		ct.AssertResponse(resp, server.PredictionSucceeded, b64encode("*bar*"), logs)
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -48,12 +58,15 @@ func TestPredictionPathOutputFilePrefixSucceeded(t *testing.T) {
 	assert.True(t, strings.HasPrefix(output, fmt.Sprintf("http://localhost:%d/upload/", ct.webhookPort)))
 	assert.Equal(t, logs, resp.Logs)
 
-	wr := ct.GetUploads()
-	assert.Equal(t, 1, len(wr))
-	body := string(wr[0].Body)
+	ul := ct.GetUploads()
+	assert.Len(t, ul, 1)
+	body := string(ul[0].Body)
 	assert.Contains(t, body, "*bar*")
 	assert.Contains(t, body, "Content-Disposition: form-data; name=\"file\"; filename=\"")
-	assert.Contains(t, body, "Content-Type: application/octet-stream")
+	if !*legacyCog {
+		// Compat: different HTTP multipart handling
+		assert.Contains(t, body, "Content-Type: application/octet-stream")
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -69,20 +82,38 @@ func TestPredictionPathUploadUrlSucceeded(t *testing.T) {
 	assert.Equal(t, server.StatusReady.String(), hc.Status)
 	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
 
-	resp := ct.Prediction(map[string]any{"p": b64encode("bar")})
-	logs := "reading input file\nwriting output file\n"
-	assert.Equal(t, server.PredictionSucceeded, resp.Status)
-	output := resp.Output.(string)
-	assert.True(t, strings.HasPrefix(output, "http://localhost:"))
-	assert.True(t, strings.Contains(output, "/upload/"))
-	assert.Equal(t, logs, resp.Logs)
+	ct.AsyncPrediction(map[string]any{"p": b64encode("bar")})
+	wr := ct.WaitForWebhookResponses()
+	ul := ct.GetUploads()
 
-	wr := ct.GetUploads()
-	assert.Equal(t, 1, len(wr))
-	body := string(wr[0].Body)
+	if *legacyCog {
+		assert.Len(t, wr, 2)
+		assert.Len(t, ul, 1)
+		logs := ""
+		// Compat: legacy Cog sends no "starting" event
+		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
+		logs += "reading input file\nwriting output file\n"
+		url := fmt.Sprintf("http://localhost:%d%s", ct.webhookPort, ul[0].Path)
+		ct.AssertResponse(wr[1], server.PredictionSucceeded, url, logs)
+	} else {
+		assert.Len(t, wr, 3)
+		assert.Len(t, ul, 1)
+		logs := ""
+		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
+		logs += "reading input file\n"
+		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
+		logs += "writing output file\n"
+		url := fmt.Sprintf("http://localhost:%d%s", ct.webhookPort, ul[0].Path)
+		ct.AssertResponse(wr[2], server.PredictionSucceeded, url, logs)
+	}
+
+	body := string(ul[0].Body)
 	assert.Contains(t, body, "*bar*")
-	assert.Contains(t, body, "Content-Disposition: form-data; name=\"file\"; filename=\"")
-	assert.Contains(t, body, "Content-Type: application/octet-stream")
+	if !*legacyCog {
+		// Compat: different HTTP multipart handling
+		assert.Contains(t, body, "Content-Disposition: form-data; name=\"file\"; filename=\"")
+		assert.Contains(t, body, "Content-Type: application/octet-stream")
+	}
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/path_test.go
+++ b/internal/tests/path_test.go
@@ -87,24 +87,27 @@ func TestPredictionPathUploadUrlSucceeded(t *testing.T) {
 	ul := ct.GetUploads()
 
 	if *legacyCog {
-		assert.Len(t, wr, 2)
+		assert.Len(t, wr, 3)
 		assert.Len(t, ul, 1)
 		logs := ""
 		// Compat: legacy Cog sends no "starting" event
 		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
-		logs += "reading input file\nwriting output file\n"
+		logs += "reading input file\n"
 		url := fmt.Sprintf("http://localhost:%d%s", ct.webhookPort, ul[0].Path)
-		ct.AssertResponse(wr[1], server.PredictionSucceeded, url, logs)
+		ct.AssertResponse(wr[1], server.PredictionProcessing, url, logs)
+		logs += "writing output file\n"
+		ct.AssertResponse(wr[2], server.PredictionSucceeded, url, logs)
 	} else {
-		assert.Len(t, wr, 3)
+		assert.Len(t, wr, 4)
 		assert.Len(t, ul, 1)
 		logs := ""
 		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
 		logs += "reading input file\n"
 		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
 		logs += "writing output file\n"
+		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
 		url := fmt.Sprintf("http://localhost:%d%s", ct.webhookPort, ul[0].Path)
-		ct.AssertResponse(wr[2], server.PredictionSucceeded, url, logs)
+		ct.AssertResponse(wr[3], server.PredictionSucceeded, url, logs)
 	}
 
 	body := string(ul[0].Body)

--- a/internal/tests/prediction_test.go
+++ b/internal/tests/prediction_test.go
@@ -70,6 +70,7 @@ func TestPredictionFailure(t *testing.T) {
 	} else {
 		assert.Equal(t, logs, resp.Logs)
 	}
+	assert.Equal(t, "prediction failed", resp.Error)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -101,7 +102,9 @@ func TestPredictionCrash(t *testing.T) {
 		resp := ct.Prediction(map[string]any{"i": 1, "s": "bar"})
 		assert.Equal(t, server.PredictionFailed, resp.Status)
 		assert.Equal(t, nil, resp.Output)
-		assert.Equal(t, "starting prediction\nprediction in progress 1/1\nprediction crashed\n", resp.Logs)
+		assert.Contains(t, resp.Logs, "starting prediction\nprediction in progress 1/1\nprediction crashed\n")
+		assert.Contains(t, resp.Logs, "SystemExit: 1\n")
+		assert.Equal(t, "prediction failed", resp.Error)
 		assert.Equal(t, "DEFUNCT", ct.HealthCheck().Status)
 	}
 

--- a/internal/tests/prediction_test.go
+++ b/internal/tests/prediction_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/replicate/go/must"
 
@@ -97,6 +98,8 @@ func TestPredictionCrash(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 		body := string(must.Get(io.ReadAll(resp.Body)))
 		assert.Equal(t, "Internal Server Error", body)
+		// Compat: flaky server?
+		time.Sleep(100 * time.Millisecond)
 		assert.Equal(t, "DEFUNCT", ct.HealthCheck().Status)
 	} else {
 		resp := ct.Prediction(map[string]any{"i": 1, "s": "bar"})

--- a/internal/tests/setup_test.go
+++ b/internal/tests/setup_test.go
@@ -36,7 +36,12 @@ func TestSetupFailure(t *testing.T) {
 	hc := e.WaitForSetup()
 	assert.Equal(t, server.StatusSetupFailed.String(), hc.Status)
 	assert.Equal(t, server.SetupFailed, hc.Setup.Status)
-	assert.Equal(t, "starting setup\nsetup failed\n", hc.Setup.Logs)
+	if *legacyCog {
+		// Compat: legacy Cog includes worker stacktrace
+		assert.Contains(t, hc.Setup.Logs, "Predictor errored during setup: setup failed\n")
+	} else {
+		assert.Equal(t, "starting setup\nsetup failed\n", hc.Setup.Logs)
+	}
 
 	e.Shutdown()
 	assert.NoError(t, e.Cleanup())
@@ -51,7 +56,13 @@ func TestSetupCrash(t *testing.T) {
 	hc := e.WaitForSetup()
 	assert.Equal(t, server.StatusSetupFailed.String(), hc.Status)
 	assert.Equal(t, server.SetupFailed, hc.Setup.Status)
-	assert.Equal(t, "starting setup\nsetup crashed\n", hc.Setup.Logs)
+	if *legacyCog {
+		// Compat: legacy Cog includes worker stacktrace
+		// Compat: "SystemExit: 1" parsing error?
+		assert.Contains(t, hc.Setup.Logs, "Predictor errored during setup: 1\n")
+	} else {
+		assert.Equal(t, "starting setup\nsetup crashed\n", hc.Setup.Logs)
+	}
 
 	e.Shutdown()
 	assert.NoError(t, e.Cleanup())

--- a/python/tests/runners/path.py
+++ b/python/tests/runners/path.py
@@ -6,9 +6,11 @@ from cog import BasePredictor, Path
 
 class Predictor(BasePredictor):
     def predict(self, p: Path) -> Path:
+        time.sleep(0.1)
         with open(p, 'r') as f:
             print('reading input file')
             s = f.read()
+        time.sleep(0.5)
         with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
             print('writing output file')
             f.write(f'*{s}*')

--- a/script/test.sh
+++ b/script/test.sh
@@ -9,31 +9,30 @@ base_dir="$(git rev-parse --show-toplevel)"
 cd "$base_dir"
 
 test_go() {
-    go test ./...
+    go test ./... "$@"
 }
 
 test_python() {
     cd "$base_dir/python"
-    uv sync --all-extras
-    .venv/bin/pytest
+    .venv/bin/pytest "$@"
 }
 
 if [ $# -eq 0 ]; then
     test_go
     test_python
 else
-    for c in "$@"; do
-        case "$c" in
-            go)
-                test_go
-                ;;
-            python)
-                test_python
-                ;;
-            *)
-                echo "Unknown test $c"
-                exit 1
-                ;;
-        esac
-    done
+    t=$1
+    shift
+    case "$t" in
+        go)
+            test_go "$@"
+            ;;
+        python)
+            test_python "$@"
+            ;;
+        *)
+            echo "Unknown test $t"
+            exit 1
+            ;;
+    esac
 fi


### PR DESCRIPTION
- **Handle legacy Cog in setup_test**
- **Handle legacy Cog in prediction_test**
- **Improve prediction failed handling**
- **Prevent concurrent webhooks on the same prediction**
- **Handle legacy Cog in path_test**
- **Handle legacy Cog in iterator_test**
- **Handle legacy Cog in filter_test**
- **Handle legacy Cog in async_prediction_test**
- **Skip async_predictor_test when testing legacy Cog**
- **Add CI for legacy Cog tests**
