### PR TITLE
Improve legacy Cog compliance

### DIFF
--- a/internal/tests/async_predictor_test.go
+++ b/internal/tests/async_predictor_test.go
@@ -35,30 +35,10 @@ func TestAsyncPredictorConcurrency(t *testing.T) {
 			bazR = append(bazR, r)
 		}
 	}
-	assert.Len(t, barR, 5)
-	assert.Len(t, bazR, 6)
-
-	barLogs := ""
-	ct.AssertResponse(barR[0], server.PredictionStarting, nil, barLogs)
-	barLogs += "starting async prediction\n"
-	ct.AssertResponse(barR[1], server.PredictionProcessing, nil, barLogs)
-	barLogs += "prediction in progress 1/1\n"
-	ct.AssertResponse(barR[2], server.PredictionProcessing, nil, barLogs)
-	barLogs += "completed async prediction\n"
-	ct.AssertResponse(barR[3], server.PredictionProcessing, nil, barLogs)
-	ct.AssertResponse(barR[4], server.PredictionSucceeded, "*bar*", barLogs)
-
-	bazLogs := ""
-	ct.AssertResponse(bazR[0], server.PredictionStarting, nil, bazLogs)
-	bazLogs += "starting async prediction\n"
-	ct.AssertResponse(bazR[1], server.PredictionProcessing, nil, bazLogs)
-	bazLogs += "prediction in progress 1/2\n"
-	ct.AssertResponse(bazR[2], server.PredictionProcessing, nil, bazLogs)
-	bazLogs += "prediction in progress 2/2\n"
-	ct.AssertResponse(bazR[3], server.PredictionProcessing, nil, bazLogs)
-	bazLogs += "completed async prediction\n"
-	ct.AssertResponse(bazR[4], server.PredictionProcessing, nil, bazLogs)
-	ct.AssertResponse(bazR[5], server.PredictionSucceeded, "*baz*", bazLogs)
+	barLogs := "starting async prediction\nprediction in progress 1/1\ncompleted async prediction\n"
+	ct.AssertResponses(barR, server.PredictionSucceeded, "*bar*", barLogs)
+	bazLogs := "starting async prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted async prediction\n"
+	ct.AssertResponses(bazR, server.PredictionSucceeded, "*baz*", bazLogs)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -76,34 +56,17 @@ func TestAsyncPredictorCanceled(t *testing.T) {
 	pid := "p01"
 	ct.AsyncPredictionWithId(pid, map[string]any{"i": 60, "s": "bar"})
 	if *legacyCog {
-		// Compat: legacy Cog buffers logging?
+		// Compat: legacy Cog does not send output webhook
 		time.Sleep(time.Second)
-		ct.Cancel(pid)
-		wr := ct.WaitForWebhookCompletion()
-		assert.Len(t, wr, 3)
-		logs := ""
-		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
-		logs += "starting async prediction\n"
-		logs += "prediction in progress 1/60\n"
-		logs += "prediction canceled\n"
-		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-		ct.AssertResponse(wr[2], server.PredictionCanceled, nil, logs)
 	} else {
 		ct.WaitForWebhook(func(response server.PredictionResponse) bool {
 			return strings.Contains(response.Logs, "prediction in progress 1/60\n")
 		})
-		ct.Cancel(pid)
-		wr := ct.WaitForWebhookCompletion()
-		assert.Len(t, wr, 4)
-		logs := ""
-		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-		logs += "starting async prediction\n"
-		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-		logs += "prediction in progress 1/60\n"
-		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-		logs += "prediction canceled\n"
-		ct.AssertResponse(wr[3], server.PredictionCanceled, nil, logs)
 	}
+	ct.Cancel(pid)
+	wr := ct.WaitForWebhookCompletion()
+	logs := "starting async prediction\nprediction in progress 1/60\nprediction canceled\n"
+	ct.AssertResponses(wr, server.PredictionCanceled, nil, logs)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/filter_test.go
+++ b/internal/tests/filter_test.go
@@ -25,35 +25,13 @@ func TestPredictionFilterAll(t *testing.T) {
 	})
 	wr := ct.WaitForWebhookCompletion()
 	if *legacyCog {
-		assert.Len(t, wr, 5)
-		logs := ""
-		// Compat: legacy Cog sends no "starting" event
-		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
-		ct.AssertResponse(wr[1], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		ct.AssertResponse(wr[2], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
 		// Compat: legacy Cog buffers logging?
-		logs += "starting prediction\n"
-		ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		logs += "prediction in progress 1/2\n"
-		logs += "prediction in progress 2/2\n"
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[4], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
+		assert.Len(t, wr, 7)
 	} else {
 		assert.Len(t, wr, 8)
-		logs := ""
-		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-		logs += "starting prediction\n"
-		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-		logs += "prediction in progress 1/2\n"
-		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-		ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		logs += "prediction in progress 2/2\n"
-		ct.AssertResponse(wr[4], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		ct.AssertResponse(wr[5], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[6], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		ct.AssertResponse(wr[7], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
 	}
+	logs := "starting prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted prediction\n"
+	ct.AssertResponses(wr, server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -73,11 +51,7 @@ func TestPredictionFilterCompleted(t *testing.T) {
 	})
 	wr := ct.WaitForWebhookCompletion()
 	assert.Len(t, wr, 1)
-	logs := ""
-	logs += "starting prediction\n"
-	logs += "prediction in progress 1/2\n"
-	logs += "prediction in progress 2/2\n"
-	logs += "completed prediction\n"
+	logs := "starting prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted prediction\n"
 	ct.AssertResponse(wr[0], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
 
 	ct.Shutdown()
@@ -99,17 +73,8 @@ func TestPredictionFilterStartedCompleted(t *testing.T) {
 	})
 	wr := ct.WaitForWebhookCompletion()
 	assert.Len(t, wr, 2)
-	logs := ""
-	if *legacyCog {
-		// Compat: legacy Cog sends no "starting" event
-		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
-	} else {
-		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-	}
-	logs += "starting prediction\n"
-	logs += "prediction in progress 1/2\n"
-	logs += "prediction in progress 2/2\n"
-	logs += "completed prediction\n"
+	ct.AssertResponse(wr[0], server.PredictionProcessing, nil, "")
+	logs := "starting prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted prediction\n"
 	ct.AssertResponse(wr[1], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
 
 	ct.Shutdown()
@@ -130,29 +95,10 @@ func TestPredictionFilterOutput(t *testing.T) {
 		server.WebhookCompleted,
 	})
 	wr := ct.WaitForWebhookCompletion()
-	if *legacyCog {
-		assert.Len(t, wr, 3)
-		logs := ""
-		// Compat: legacy Cog sends no "starting" event
-		ct.AssertResponse(wr[0], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		ct.AssertResponse(wr[1], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		// Compat: legacy Cog buffers logging?
-		logs += "starting prediction\n"
-		logs += "prediction in progress 1/2\n"
-		logs += "prediction in progress 2/2\n"
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[2], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
-	} else {
-		assert.Len(t, wr, 3)
-		logs := ""
-		logs += "starting prediction\n"
-		logs += "prediction in progress 1/2\n"
-		ct.AssertResponse(wr[0], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		logs += "prediction in progress 2/2\n"
-		ct.AssertResponse(wr[1], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[2], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
-	}
+
+	assert.Len(t, wr, 3)
+	logs := "starting prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted prediction\n"
+	ct.AssertResponses(wr, server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -172,29 +118,9 @@ func TestPredictionFilterLogs(t *testing.T) {
 		server.WebhookCompleted,
 	})
 	wr := ct.WaitForWebhookCompletion()
-	if *legacyCog {
-		assert.Len(t, wr, 2)
-		logs := ""
-		logs += "starting prediction\n"
-		ct.AssertResponse(wr[0], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		logs += "prediction in progress 1/2\n"
-		logs += "prediction in progress 2/2\n"
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[1], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
-
-	} else {
-		assert.Len(t, wr, 5)
-		logs := ""
-		logs += "starting prediction\n"
-		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
-		logs += "prediction in progress 1/2\n"
-		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-		logs += "prediction in progress 2/2\n"
-		ct.AssertResponse(wr[2], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		ct.AssertResponse(wr[4], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
-	}
+	assert.Len(t, wr, 5)
+	logs := "starting prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted prediction\n"
+	ct.AssertResponses(wr, server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/iterator_test.go
+++ b/internal/tests/iterator_test.go
@@ -35,36 +35,8 @@ func testPredictionIteratorSucceeded(t *testing.T, module string) {
 
 	ct.AsyncPrediction(map[string]any{"i": 2, "s": "bar"})
 	wr := ct.WaitForWebhookCompletion()
-	if *legacyCog {
-		assert.Len(t, wr, 5)
-		logs := ""
-		// Compat: legacy Cog sends no "starting" event
-		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
-		ct.AssertResponse(wr[1], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		ct.AssertResponse(wr[2], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		// Compat: legacy Cog buffers logging?
-		logs += "starting prediction\n"
-		ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		logs += "prediction in progress 1/2\n"
-		logs += "prediction in progress 2/2\n"
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[4], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
-	} else {
-		assert.Len(t, wr, 8)
-		logs := ""
-		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-		logs += "starting prediction\n"
-		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-		logs += "prediction in progress 1/2\n"
-		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-		ct.AssertResponse(wr[3], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		logs += "prediction in progress 2/2\n"
-		ct.AssertResponse(wr[4], server.PredictionProcessing, []any{"*bar-0*"}, logs)
-		ct.AssertResponse(wr[5], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		logs += "completed prediction\n"
-		ct.AssertResponse(wr[6], server.PredictionProcessing, []any{"*bar-0*", "*bar-1*"}, logs)
-		ct.AssertResponse(wr[7], server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
-	}
+	logs := "starting prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted prediction\n"
+	ct.AssertResponses(wr, server.PredictionSucceeded, []any{"*bar-0*", "*bar-1*"}, logs)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())
@@ -95,31 +67,10 @@ func TestPredictionAsyncIteratorConcurrency(t *testing.T) {
 			bazR = append(bazR, r)
 		}
 	}
-	assert.Len(t, barR, 6)
-	barLogs := ""
-	ct.AssertResponse(barR[0], server.PredictionStarting, nil, barLogs)
-	barLogs += "starting prediction\n"
-	ct.AssertResponse(barR[1], server.PredictionProcessing, nil, barLogs)
-	barLogs += "prediction in progress 1/1\n"
-	ct.AssertResponse(barR[2], server.PredictionProcessing, nil, barLogs)
-	ct.AssertResponse(barR[3], server.PredictionProcessing, []any{"*bar-0*"}, barLogs)
-	barLogs += "completed prediction\n"
-	ct.AssertResponse(barR[4], server.PredictionProcessing, []any{"*bar-0*"}, barLogs)
-	ct.AssertResponse(barR[5], server.PredictionSucceeded, []any{"*bar-0*"}, barLogs)
-	assert.Len(t, bazR, 8)
-	bazLogs := ""
-	ct.AssertResponse(bazR[0], server.PredictionStarting, nil, bazLogs)
-	bazLogs += "starting prediction\n"
-	ct.AssertResponse(bazR[1], server.PredictionProcessing, nil, bazLogs)
-	bazLogs += "prediction in progress 1/2\n"
-	ct.AssertResponse(bazR[2], server.PredictionProcessing, nil, bazLogs)
-	ct.AssertResponse(bazR[3], server.PredictionProcessing, []any{"*baz-0*"}, bazLogs)
-	bazLogs += "prediction in progress 2/2\n"
-	ct.AssertResponse(bazR[4], server.PredictionProcessing, []any{"*baz-0*"}, bazLogs)
-	ct.AssertResponse(bazR[5], server.PredictionProcessing, []any{"*baz-0*", "*baz-1*"}, bazLogs)
-	bazLogs += "completed prediction\n"
-	ct.AssertResponse(bazR[6], server.PredictionProcessing, []any{"*baz-0*", "*baz-1*"}, bazLogs)
-	ct.AssertResponse(bazR[7], server.PredictionSucceeded, []any{"*baz-0*", "*baz-1*"}, bazLogs)
+	barLogs := "starting prediction\nprediction in progress 1/1\ncompleted prediction\n"
+	ct.AssertResponses(barR, server.PredictionSucceeded, []any{"*bar-0*"}, barLogs)
+	bazLogs := "starting prediction\nprediction in progress 1/2\nprediction in progress 2/2\ncompleted prediction\n"
+	ct.AssertResponses(bazR, server.PredictionSucceeded, []any{"*baz-0*", "*baz-1*"}, bazLogs)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/path_test.go
+++ b/internal/tests/path_test.go
@@ -85,29 +85,10 @@ func TestPredictionPathUploadUrlSucceeded(t *testing.T) {
 	wr := ct.WaitForWebhookCompletion()
 	ul := ct.GetUploads()
 
-	if *legacyCog {
-		assert.Len(t, wr, 3)
-		assert.Len(t, ul, 1)
-		logs := ""
-		// Compat: legacy Cog sends no "starting" event
-		ct.AssertResponse(wr[0], server.PredictionProcessing, nil, logs)
-		logs += "reading input file\n"
-		url := fmt.Sprintf("http://localhost:%d%s", ct.webhookPort, ul[0].Path)
-		ct.AssertResponse(wr[1], server.PredictionProcessing, url, logs)
-		logs += "writing output file\n"
-		ct.AssertResponse(wr[2], server.PredictionSucceeded, url, logs)
-	} else {
-		assert.Len(t, wr, 4)
-		assert.Len(t, ul, 1)
-		logs := ""
-		ct.AssertResponse(wr[0], server.PredictionStarting, nil, logs)
-		logs += "reading input file\n"
-		ct.AssertResponse(wr[1], server.PredictionProcessing, nil, logs)
-		logs += "writing output file\n"
-		ct.AssertResponse(wr[2], server.PredictionProcessing, nil, logs)
-		url := fmt.Sprintf("http://localhost:%d%s", ct.webhookPort, ul[0].Path)
-		ct.AssertResponse(wr[3], server.PredictionSucceeded, url, logs)
-	}
+	assert.Len(t, ul, 1)
+	logs := "reading input file\nwriting output file\n"
+	url := fmt.Sprintf("http://localhost:%d%s", ct.webhookPort, ul[0].Path)
+	ct.AssertResponses(wr, server.PredictionSucceeded, url, logs)
 
 	body := string(ul[0].Body)
 	assert.Contains(t, body, "*bar*")

--- a/internal/tests/prediction_test.go
+++ b/internal/tests/prediction_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -62,11 +61,8 @@ func TestPredictionFailure(t *testing.T) {
 	assert.Equal(t, server.PredictionFailed, resp.Status)
 	assert.Equal(t, nil, resp.Output)
 	logs := "starting prediction\nprediction in progress 1/1\nprediction failed\n"
-	if *legacyCog {
-		assert.Contains(t, resp.Logs, fmt.Sprintf("Exception: prediction failed\n%s", logs))
-	} else {
-		assert.Equal(t, logs, resp.Logs)
-	}
+	// Compat: legacy Cog also includes Traceback
+	assert.Contains(t, resp.Logs, logs)
 	assert.Equal(t, "prediction failed", resp.Error)
 
 	ct.Shutdown()


### PR DESCRIPTION
* Run legacy Cog with PYTHONUNBUFFERED
* Send "processing" instead of "start" webhook
* Simplify webhook sequence assertions
