### PR TITLE
Wait for cog wait file to exist in golang server

### DIFF
--- a/cmd/cog-server/main.go
+++ b/cmd/cog-server/main.go
@@ -24,7 +24,7 @@ import (
 
 var logger = logging.New("cog-server")
 
-var ErrTimedOut = errors.New("Timed out waiting for COG_WAIT_FILE")
+var ErrTimedOut = errors.New("timed out waiting for COG_WAIT_FILE")
 
 type Config struct {
 	Host                  string `ff:"long: host, default: 0.0.0.0, usage: HTTP server host"`
@@ -140,12 +140,13 @@ func main() {
 func waitCogWaitFile(log *zap.SugaredLogger) error {
 	waitFileLocation, ok := os.LookupEnv("COG_WAIT_FILE")
 	if !ok {
-		log.Debugw("COG_WAIT_FILE not set, skipping wait")
+		log.Debug("COG_WAIT_FILE not set, skipping wait")
 		return nil
 	}
 	for i := 0; i < 10; i++ {
 		_, err := os.Stat(waitFileLocation)
 		if errors.Is(err, os.ErrNotExist) {
+			// Check if we hit the max number of waits
 			if i == 9 {
 				return ErrTimedOut
 			}

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -99,8 +99,12 @@ func NewRunner(workingDir, moduleName, className string, awaitExplicitShutdown b
 		"-u",
 		"-m", "coglet",
 		"--working-dir", workingDir,
-		"--module-name", moduleName,
-		"--class-name", className,
+	}
+	if moduleName != "" {
+		args = append(args, "--module-name", moduleName)
+	}
+	if className != "" {
+		args = append(args, "--class-name", className)
 	}
 	cmd := exec.Command("python3", args...)
 	return &Runner{


### PR DESCRIPTION
### Summary

We need to wait for the `COG_WAIT_FILE` to exist before we try to read the cog yaml