### PR TITLE
Add test_inputs

### DIFF
--- a/cmd/cog/main.go
+++ b/cmd/cog/main.go
@@ -105,6 +105,27 @@ func serverCommand() *ff.Command {
 	}
 }
 
+func testCommand() *ff.Command {
+	log := logger.Sugar()
+
+	flags := ff.NewFlagSet("test")
+
+	return &ff.Command{
+		Name:  "test",
+		Usage: "test [FLAGS]",
+		Flags: flags,
+		Exec: func(ctx context.Context, args []string) error {
+			m, c, err := util.PredictFromCogYaml()
+			if err != nil {
+				log.Errorw("failed to parse cog.yaml", "err", err)
+				return err
+			}
+			bin := must.Get(exec.LookPath("python3"))
+			return syscall.Exec(bin, []string{bin, "-m", "coglet.test", m, c}, os.Environ())
+		},
+	}
+}
+
 func main() {
 	log := logger.Sugar()
 	flags := ff.NewFlagSet("cog")
@@ -118,6 +139,7 @@ func main() {
 		Subcommands: []*ff.Command{
 			schemaCommand(),
 			serverCommand(),
+			testCommand(),
 		},
 	}
 	err := cmd.ParseAndRun(context.Background(), os.Args[1:])

--- a/python/cog/command/test.py
+++ b/python/cog/command/test.py
@@ -1,0 +1,7 @@
+import sys
+
+from cog.command import go_cog
+
+# Lightweight wrapper from `python3 -m cog.command.test` to `cog test`
+if __name__ == '__main__':
+    go_cog.run('test', sys.argv[1:])

--- a/python/coglet/runner.py
+++ b/python/coglet/runner.py
@@ -2,90 +2,9 @@ import importlib
 import inspect
 import os
 import os.path
-import re
 from typing import Any, AsyncGenerator, Dict
 
-from coglet import adt, api, util
-
-
-def _kwargs(adt_ins: Dict[str, adt.Input], inputs: Dict[str, Any]) -> Dict[str, Any]:
-    kwargs: Dict[str, Any] = {}
-    for name, value in inputs.items():
-        assert name in adt_ins, f'unknown field: {name}'
-        adt_in = adt_ins[name]
-        cog_t = adt_in.type
-        if adt_in.is_list:
-            assert all(util.check_value(cog_t, v) for v in value), (
-                f'incompatible value for field: {name}={value}'
-            )
-            value = [util.normalize_value(cog_t, v) for v in value]
-        else:
-            assert util.check_value(cog_t, value), (
-                f'incompatible value for field: {name}={value}'
-            )
-            value = util.normalize_value(cog_t, value)
-        kwargs[name] = value
-    for name, adt_in in adt_ins.items():
-        if name not in kwargs:
-            assert adt_in.default is not None, (
-                f'missing default value for field: {name}'
-            )
-            kwargs[name] = adt_in.default
-
-        values = kwargs[name] if adt_in.is_list else [kwargs[name]]
-        v = kwargs[name]
-        if adt_in.ge is not None:
-            assert (x >= adt_in.ge for x in values), (
-                f'validation failure: >= {adt_in.ge} for field: {name}={v}'
-            )
-        if adt_in.le is not None:
-            assert (x <= adt_in.le for x in values), (
-                f'validation failure: <= {adt_in.le} for field: {name}={v}'
-            )
-        if adt_in.min_length is not None:
-            assert (len(x) >= adt_in.min_length for x in values), (
-                f'validation failure: len(x) >= {adt_in.min_length} for field: {name}={v}'
-            )
-        if adt_in.max_length is not None:
-            assert (len(x) <= adt_in.max_length for x in values), (
-                f'validation failure: len(x) <= {adt_in.max_length} for field: {name}={v}'
-            )
-        if adt_in.regex is not None:
-            p = re.compile(adt_in.regex)
-            assert all(p.match(x) is not None for x in values), (
-                f'validation failure: regex match for field: {name}={v}'
-            )
-        if adt_in.choices is not None:
-            assert all(x in adt_in.choices for x in values), (
-                f'validation failure: choices for field: {name}={v}'
-            )
-    return kwargs
-
-
-def _check_output(adt_out: adt.Output, output: Any) -> Any:
-    if adt_out.kind is adt.Kind.SINGLE:
-        assert adt_out.type is not None, 'missing output type'
-        assert util.check_value(adt_out.type, output), f'incompatible output: {output}'
-        return util.normalize_value(adt_out.type, output)
-    elif adt_out.kind is adt.Kind.LIST:
-        assert adt_out.type is not None, 'missing output type'
-        assert type(output) is list, 'output is not list'
-        for i, x in enumerate(output):
-            assert util.check_value(adt_out.type, x), (
-                f'incompatible output element: {x}'
-            )
-            output[i] = util.normalize_value(adt_out.type, x)
-        return output
-    elif adt_out.kind == adt.Kind.OBJECT:
-        assert adt_out.fields is not None, 'missing output fields'
-        for name, tpe in adt_out.fields.items():
-            assert hasattr(output, name), f'missing output field: {name}'
-            value = getattr(output, name)
-            assert util.check_value(tpe, value), (
-                f'incompatible output for field: {name}={value}'
-            )
-            setattr(output, name, util.normalize_value(tpe, value))
-        return output
+from coglet import adt, api, inspector, util
 
 
 # Reflectively run a Cog predictor
@@ -100,6 +19,16 @@ class Runner:
         self.is_async_predict = inspect.iscoroutinefunction(
             self.predictor.predict
         ) or inspect.isasyncgenfunction(self.predictor.predict)
+
+    async def test(self) -> Any:
+        inputs = inspector.get_test_inputs(self.predictor, self.inputs)
+        if self.is_iter():
+            output = []
+            async for o in self.predict_iter(inputs):
+                output.append(o)
+        else:
+            output = await self.predict(inputs)
+        return output
 
     async def setup(self) -> None:
         kwargs: Dict[str, Any] = {}
@@ -128,18 +57,18 @@ class Runner:
 
     async def predict(self, inputs: Dict[str, Any]) -> Any:
         assert not self.is_iter(), 'predict returns iterator, call predict_iter instead'
-        kwargs = _kwargs(self.inputs, inputs)
+        kwargs = inspector.check_input(self.inputs, inputs)
         if self.is_async_predict:
             output = await self.predictor.predict(**kwargs)
         else:
             output = self.predictor.predict(**kwargs)
-        return _check_output(self.output, output)
+        return inspector.check_output(self.output, output)
 
     async def predict_iter(self, inputs: Dict[str, Any]) -> AsyncGenerator[Any, None]:
         assert self.is_iter(), 'predict does not return iterator, call predict instead'
         assert self.output.type is not None, 'missing output type'
 
-        kwargs = _kwargs(self.inputs, inputs)
+        kwargs = inspector.check_input(self.inputs, inputs)
         if self.is_async_predict:
             async for x in self.predictor.predict(**kwargs):
                 assert util.check_value(self.output.type, x), (

--- a/python/coglet/schema.py
+++ b/python/coglet/schema.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import os.path
 import sys
@@ -29,6 +30,12 @@ def main():
         # - Bad input/output types
         # - Libraries downloading weights on init
         p = inspector.create_predictor(sys.argv[1], sys.argv[2])
+
+        # Check that test_inputs exists and is valid
+        module = importlib.import_module(p.module_name)
+        cls = getattr(module, p.class_name)
+        inspector.get_test_inputs(cls, p.inputs)
+
         s = schemas.to_json_schema(p)
     except Exception as e:
         sys.stdout.write = _stdout_write

--- a/python/coglet/test.py
+++ b/python/coglet/test.py
@@ -1,0 +1,24 @@
+import asyncio
+import os.path
+import sys
+
+from coglet import inspector, runner
+
+
+async def main() -> int:
+    if len(sys.argv) != 3:
+        print(f'Usage {os.path.basename(sys.argv[0])} <MODULE> <CLASS>')
+        sys.exit(1)
+
+    p = inspector.create_predictor(sys.argv[1], sys.argv[2])
+    r = runner.Runner(p)
+
+    await r.setup()
+    output = await r.test()
+    print(f'Predictor passed test: {output}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(asyncio.run(main()))

--- a/python/tests/runners/async_iterator.py
+++ b/python/tests/runners/async_iterator.py
@@ -5,6 +5,8 @@ from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'i': 3, 's': 'foo'}
+
     async def predict(self, i: int, s: str) -> Iterator[str]:
         await asyncio.sleep(0.1)
         print('starting prediction')

--- a/python/tests/runners/async_sleep.py
+++ b/python/tests/runners/async_sleep.py
@@ -5,6 +5,8 @@ from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'i': 0, 's': 'foo'}
+
     async def setup(self) -> None:
         print('starting async setup')
         i = int(os.environ.get('SETUP_SLEEP', '0'))

--- a/python/tests/runners/concat_iterator.py
+++ b/python/tests/runners/concat_iterator.py
@@ -4,6 +4,8 @@ from cog import BasePredictor, ConcatenateIterator
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'i': 3, 's': 'foo'}
+
     def predict(self, i: int, s: str) -> ConcatenateIterator[str]:
         time.sleep(0.1)
         print('starting prediction')

--- a/python/tests/runners/iterator.py
+++ b/python/tests/runners/iterator.py
@@ -5,6 +5,8 @@ from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'i': 3, 's': 'foo'}
+
     def predict(self, i: int, s: str) -> Iterator[str]:
         time.sleep(0.1)
         print('starting prediction')

--- a/python/tests/runners/output.py
+++ b/python/tests/runners/output.py
@@ -10,6 +10,8 @@ class Output(BaseModel):
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'p': '/etc/hostname'}
+
     def predict(self, p: Path) -> Output:
         time.sleep(0.1)
         with open(p, 'r') as f:

--- a/python/tests/runners/path.py
+++ b/python/tests/runners/path.py
@@ -5,6 +5,8 @@ from cog import BasePredictor, Path
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'p': '/etc/hostname'}
+
     def predict(self, p: Path) -> Path:
         time.sleep(0.1)
         with open(p, 'r') as f:

--- a/python/tests/runners/sleep.py
+++ b/python/tests/runners/sleep.py
@@ -7,6 +7,8 @@ from cog.server.exceptions import CancelationException
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'i': 0, 's': 'foo'}
+
     def setup(self) -> None:
         print('starting setup')
         i = int(os.environ.get('SETUP_SLEEP', '0'))

--- a/python/tests/runners/tqdm_out.py
+++ b/python/tests/runners/tqdm_out.py
@@ -6,6 +6,8 @@ from cog import BasePredictor
 
 
 class Predictor(BasePredictor):
+    test_inputs = {'s': 'foo'}
+
     def setup(self) -> None:
         print('starting async setup')
         for _ in tqdm(range(500)):

--- a/python/tests/test_test_inputs.py
+++ b/python/tests/test_test_inputs.py
@@ -1,0 +1,22 @@
+import os.path
+import pkgutil
+from typing import List
+
+import pytest
+
+from coglet import inspector, runner
+
+
+def get_predictors() -> List[str]:
+    schemas_dir = os.path.join(os.path.dirname(__file__), 'runners')
+    return [name for _, name, _ in pkgutil.iter_modules([schemas_dir])]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('predictor', get_predictors())
+async def test_test_inputs(predictor):
+    module_name = f'tests.runners.{predictor}'
+    p = inspector.create_predictor(module_name, 'Predictor')
+    r = runner.Runner(p)
+
+    assert await r.test()


### PR DESCRIPTION
* Check for `predictor.test_inputs` in `coglet.schema` command.
  * If `test_inputs` is missing, each `Input` must have a default value and they'll be used for testing
  * `test_inputs` will be type checked with the same logic when running normal prediction loop
* Run `predictor.predict()` with `test_inputs` in `coglet.test`
* Add `python3 -m cog.command.test` entrypoint for consistency