### PR TITLE
Make setup logs live in /health-check

### DIFF
--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -505,6 +505,7 @@ func (r *Runner) log(line string) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		r.logs = append(r.logs, line)
+		r.setupResult.Logs = util.JoinLogs(r.logs)
 	}
 	fmt.Println(line)
 }


### PR DESCRIPTION
So that we can include logs received so far in setup time out result.