### PR TITLE
Support procedure mode

### DIFF
--- a/internal/server/openapi-procedure.json
+++ b/internal/server/openapi-procedure.json
@@ -229,31 +229,6 @@
         "title": "HTTPValidationError"
       },
       "Input": {
-        "properties": {
-          "token": {
-            "type": "string",
-            "format": "password",
-            "title": "Token",
-            "x-cog-secret": true,
-            "x-order": 0
-          },
-          "procedure_source_url": {
-            "type": "string",
-            "title": "Procedure Source Url",
-            "x-order": 1
-          },
-          "inputs_json": {
-            "type": "string",
-            "title": "Inputs Json",
-            "x-order": 2
-          }
-        },
-        "type": "object",
-        "required": [
-          "token",
-          "procedure_source_url",
-          "inputs_json"
-        ],
         "title": "Input"
       },
       "Output": {
@@ -295,10 +270,24 @@
               "logs",
               "completed"
             ]
+          },
+          "token": {
+            "type": "string",
+            "format": "password",
+            "title": "Token",
+            "x-cog-secret": true
+          },
+          "procedure_source_url": {
+            "type": "string",
+            "title": "Procedure Source Url"
           }
         },
         "type": "object",
-        "title": "PredictionRequest"
+        "title": "PredictionRequest",
+        "required": [
+          "token",
+          "procedure_source_url"
+        ]
       },
       "PredictionResponse": {
         "properties": {

--- a/internal/server/openapi-procedure.json
+++ b/internal/server/openapi-procedure.json
@@ -1,0 +1,412 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Cog",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/shutdown": {
+      "post": {
+        "summary": "Start Shutdown",
+        "operationId": "start_shutdown_shutdown_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Start Shutdown Shutdown Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Root  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health-check": {
+      "get": {
+        "summary": "Healthcheck",
+        "operationId": "healthcheck_health_check_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Healthcheck Health Check Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions": {
+      "post": {
+        "summary": "Predict",
+        "description": "Run a single prediction on the model",
+        "operationId": "predict_predictions_post",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Prefer"
+            },
+            "name": "prefer",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}": {
+      "put": {
+        "summary": "Predict Idempotent",
+        "description": "Run a single prediction on the model (idempotent creation).",
+        "operationId": "predict_idempotent_predictions__prediction_id__put",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            },
+            "name": "prediction_id",
+            "in": "path"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Prefer"
+            },
+            "name": "prefer",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PredictionRequest"
+                  }
+                ],
+                "title": "Prediction Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}/cancel": {
+      "post": {
+        "summary": "Cancel",
+        "description": "Cancel a running prediction",
+        "operationId": "cancel_predictions__prediction_id__cancel_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            },
+            "name": "prediction_id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Cancel Predictions  Prediction Id  Cancel Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Input": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "format": "password",
+            "title": "Token",
+            "x-cog-secret": true,
+            "x-order": 0
+          },
+          "procedure_source_url": {
+            "type": "string",
+            "title": "Procedure Source Url",
+            "x-order": 1
+          },
+          "inputs_json": {
+            "type": "string",
+            "title": "Inputs Json",
+            "x-order": 2
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "procedure_source_url",
+          "inputs_json"
+        ],
+        "title": "Input"
+      },
+      "Output": {
+        "title": "Output"
+      },
+      "PredictionRequest": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "output_file_prefix": {
+            "type": "string",
+            "title": "Output File Prefix"
+          },
+          "webhook": {
+            "type": "string",
+            "maxLength": 65536,
+            "minLength": 1,
+            "format": "uri",
+            "title": "Webhook"
+          },
+          "webhook_events_filter": {
+            "items": {
+              "$ref": "#/components/schemas/WebhookEvent"
+            },
+            "type": "array",
+            "default": [
+              "start",
+              "output",
+              "logs",
+              "completed"
+            ]
+          }
+        },
+        "type": "object",
+        "title": "PredictionRequest"
+      },
+      "PredictionResponse": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input"
+          },
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Completed At"
+          },
+          "logs": {
+            "type": "string",
+            "title": "Logs",
+            "default": ""
+          },
+          "error": {
+            "type": "string",
+            "title": "Error"
+          },
+          "status": {
+            "$ref": "#/components/schemas/Status"
+          },
+          "metrics": {
+            "type": "object",
+            "title": "Metrics"
+          }
+        },
+        "type": "object",
+        "title": "PredictionResponse"
+      },
+      "Status": {
+        "type": "string",
+        "enum": [
+          "starting",
+          "processing",
+          "succeeded",
+          "canceled",
+          "failed"
+        ],
+        "title": "Status",
+        "description": "An enumeration."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WebhookEvent": {
+        "type": "string",
+        "enum": [
+          "start",
+          "output",
+          "logs",
+          "completed"
+        ],
+        "title": "WebhookEvent",
+        "description": "An enumeration."
+      }
+    }
+  }
+}

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -118,6 +118,17 @@ func NewRunner(awaitExplicitShutdown bool, uploadUrl string) *Runner {
 	}
 }
 
+func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string, token string) *Runner {
+	r := NewRunner(awaitExplicitShutdown, uploadUrl)
+	r.cmd.Dir = srcDir
+	r.cmd.Env = append(os.Environ(), fmt.Sprintf("REPLICATE_API_TOKEN=%s", token))
+	return r
+}
+
+func (r *Runner) SrcDir() string {
+	return r.cmd.Dir
+}
+
 func (r *Runner) Start() error {
 	log := logger.Sugar()
 	cmdStart := make(chan bool)
@@ -284,7 +295,7 @@ func (r *Runner) config() {
 
 	// Otherwise read from cog.yaml
 	if moduleName == "" || predictorName == "" {
-		y, err := util.ReadCogYaml()
+		y, err := util.ReadCogYaml(r.SrcDir())
 		if err != nil {
 			log.Errorw("failed to read cog.yaml", "err", err)
 			panic(err)

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -118,10 +118,9 @@ func NewRunner(awaitExplicitShutdown bool, uploadUrl string) *Runner {
 	}
 }
 
-func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string, token string) *Runner {
+func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string) *Runner {
 	r := NewRunner(awaitExplicitShutdown, uploadUrl)
 	r.cmd.Dir = srcDir
-	r.cmd.Env = append(os.Environ(), fmt.Sprintf("REPLICATE_API_TOKEN=%s", token))
 	return r
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -144,7 +144,7 @@ func (h *Handler) updateRunner(srcDir, token string) error {
 
 	// Start new runner
 	log.Infow("starting procedure runner", "src_dir", srcDir)
-	runner := NewProcedureRunner(h.cfg.AwaitExplicitShutdown, h.cfg.UploadUrl, srcDir, token)
+	runner := NewProcedureRunner(h.cfg.AwaitExplicitShutdown, h.cfg.UploadUrl, srcDir)
 	if err := runner.Start(); err != nil {
 		return err
 	}

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -1,9 +1,6 @@
 package server
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/url"
 	"syscall"
 )
 
@@ -92,44 +89,6 @@ type SetupResult struct {
 	Logs        string      `json:"logs,omitempty"`
 }
 
-type ProcedureRequest struct {
-	ProcedureSourceURL string `json:"procedure_source_url"`
-	Token              string `json:"token"`
-	InputsJson         any    `json:"inputs_json"`
-}
-
-func ParseProcedureRequest(v any) (ProcedureRequest, error) {
-	r := ProcedureRequest{}
-	m, ok := v.(map[string]any)
-	if !ok {
-		return r, fmt.Errorf("invalid procedure request %v", v)
-	}
-	if v, ok := m["procedure_source_url"]; ok {
-		vs := v.(string)
-		u, err := url.Parse(vs)
-		if err != nil {
-			return r, err
-		}
-		if u.Scheme != "file" {
-			return r, fmt.Errorf("invalid procedure_source_url %s", vs)
-		}
-		r.ProcedureSourceURL = u.Path
-	}
-	if v, ok := m["token"]; ok {
-		r.Token = v.(string)
-	}
-	if v, ok := m["inputs_json"]; ok {
-		vs, ok := v.(string)
-		if !ok {
-			return r, fmt.Errorf("invalid inputs_json %v", v)
-		}
-		if err := json.Unmarshal([]byte(vs), &r.InputsJson); err != nil {
-			return r, err
-		}
-	}
-	return r, nil
-}
-
 type PredictionRequest struct {
 	Input               any            `json:"input"`
 	Id                  string         `json:"id"`
@@ -137,6 +96,8 @@ type PredictionRequest struct {
 	Webhook             string         `json:"webhook,omitempty"`
 	WebhookEventsFilter []WebhookEvent `json:"webhook_events_filter,omitempty"`
 	OutputFilePrefix    string         `json:"output_file_prefix,omitempty"`
+	ProcedureSourceURL  string         `json:"procedure_source_url"`
+	Token               string         `json:"token"`
 }
 
 type PredictionResponse struct {

--- a/internal/tests/procedure_test.go
+++ b/internal/tests/procedure_test.go
@@ -1,0 +1,53 @@
+package tests
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/replicate/go/must"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/replicate/cog-runtime/internal/server"
+)
+
+func procedureRequest(procedure string, token string, inputs map[string]any) map[string]any {
+	r := make(map[string]any)
+	r["procedure_source_url"] = fmt.Sprintf("file://%s/python/tests/procedures/%s", basePath, procedure)
+	r["token"] = token
+	r["inputs_json"] = string(must.Get(json.Marshal(inputs)))
+	return r
+}
+
+func TestProcedure(t *testing.T) {
+	if *legacyCog {
+		dir := path.Join(basePath, "..", "pipelines-runtime")
+		if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+			t.Logf("pipelines-runtime not found, skipping legacy cog test")
+			t.SkipNow()
+		}
+	}
+
+	ct := NewCogProcedureTest(t)
+	assert.NoError(t, ct.Start())
+
+	hc := ct.WaitForSetup()
+	assert.Equal(t, server.StatusReady.String(), hc.Status)
+	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
+
+	resp1 := ct.Prediction(procedureRequest("foo", "bar", map[string]any{"s": "foobar"}))
+	assert.Equal(t, server.PredictionSucceeded, resp1.Status)
+	assert.Equal(t, "s=foobar, token=bar", resp1.Output)
+	assert.Equal(t, resp1.Logs, "predicting foo\n")
+
+	resp2 := ct.Prediction(procedureRequest("bar", "baz", map[string]any{"i": 123456}))
+	assert.Equal(t, server.PredictionSucceeded, resp2.Status)
+	assert.Equal(t, "i=123456, token=baz", resp2.Output)
+	assert.Equal(t, resp2.Logs, "predicting bar\n")
+
+	ct.Shutdown()
+	assert.NoError(t, ct.Cleanup())
+}

--- a/internal/tests/procedure_test.go
+++ b/internal/tests/procedure_test.go
@@ -73,12 +73,12 @@ func TestProcedure(t *testing.T) {
 	resp1 := prediction("foo", "bar", map[string]any{"s": "foobar"})
 	assert.Equal(t, server.PredictionSucceeded, resp1.Status)
 	assert.Equal(t, "s=foobar, token=bar", resp1.Output)
-	assert.Equal(t, resp1.Logs, "predicting foo\n")
+	assert.Contains(t, resp1.Logs, "predicting foo\n")
 
 	resp2 := prediction("bar", "baz", map[string]any{"i": 123456})
 	assert.Equal(t, server.PredictionSucceeded, resp2.Status)
 	assert.Equal(t, "i=123456, token=baz", resp2.Output)
-	assert.Equal(t, resp2.Logs, "predicting bar\n")
+	assert.Contains(t, resp2.Logs, "predicting bar\n")
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/procedure_test.go
+++ b/internal/tests/procedure_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"testing"
@@ -38,12 +39,43 @@ func TestProcedure(t *testing.T) {
 	assert.Equal(t, server.StatusReady.String(), hc.Status)
 	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
 
-	resp1 := ct.Prediction(procedureRequest("foo", "bar", map[string]any{"s": "foobar"}))
+	prediction := func(procedure, token string, input map[string]any) server.PredictionResponse {
+		url := fmt.Sprintf("file://%s/python/tests/procedures/%s", basePath, procedure)
+		if *legacyCog {
+			// Compat: legacy pipelines-runtime uses a wrapper predictor with these 3 inputs
+			// So the request looks like:
+			/*
+				{
+				  "input": {
+				    "procedure_source_url": "file:///<path>",
+				    "token": "***",
+				    "inputs_json": "{\"s\":\"\"}"
+				  }
+				}
+			*/
+			req := make(map[string]any)
+			req["procedure_source_url"] = fmt.Sprintf("file://%s/python/tests/procedures/%s", basePath, procedure)
+			req["token"] = token
+			req["inputs_json"] = string(must.Get(json.Marshal(input)))
+			return ct.Prediction(req)
+		} else {
+			// cog-runtime moves procedure_source_url and token to top level of PredictionRequest
+			// So no more inputs_json unwrapping
+			req := server.PredictionRequest{
+				ProcedureSourceURL: url,
+				Token:              token,
+				Input:              input,
+			}
+			return ct.prediction(http.MethodPost, "/predictions", req)
+		}
+	}
+
+	resp1 := prediction("foo", "bar", map[string]any{"s": "foobar"})
 	assert.Equal(t, server.PredictionSucceeded, resp1.Status)
 	assert.Equal(t, "s=foobar, token=bar", resp1.Output)
 	assert.Equal(t, resp1.Logs, "predicting foo\n")
 
-	resp2 := ct.Prediction(procedureRequest("bar", "baz", map[string]any{"i": 123456}))
+	resp2 := prediction("bar", "baz", map[string]any{"i": 123456})
 	assert.Equal(t, server.PredictionSucceeded, resp2.Status)
 	assert.Equal(t, "i=123456, token=baz", resp2.Output)
 	assert.Equal(t, resp2.Logs, "predicting bar\n")

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base32"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -24,9 +25,9 @@ type CogYaml struct {
 	Predict     string      `yaml:"predict"`
 }
 
-func ReadCogYaml() (*CogYaml, error) {
+func ReadCogYaml(dir string) (*CogYaml, error) {
 	var cogYaml CogYaml
-	bs, err := os.ReadFile("cog.yaml")
+	bs, err := os.ReadFile(filepath.Join(dir, "cog.yaml"))
 	if err != nil {
 		return nil, err
 	}
@@ -62,6 +63,10 @@ const TimeLayout = "2006-01-02T15:04:05.999999-07:00"
 func NowIso() string {
 	// Python: datetime.now(tz=timezone.utc).isoformat()
 	return time.Now().UTC().Format(TimeLayout)
+}
+
+func FormatTime(t time.Time) string {
+	return t.UTC().Format(TimeLayout)
 }
 
 func ParseTime(t string) time.Time {

--- a/python/coglet/file_runner.py
+++ b/python/coglet/file_runner.py
@@ -166,6 +166,12 @@ class FileRunner:
             'started_at': util.now_iso(),
             'status': 'starting',
         }
+        context_dict = {}
+        if "token" in resp:
+            context_dict["token"] = resp["token"]
+        if "procedure_source_url" in resp:
+            context_dict["procedure_source_url"] = resp["procedure_source_url"]
+        scope.contexts[pid] = context_dict
         # Write partial response, e.g. starting, processing, if webhook is set
         is_async = 'webhook' in req
         epoch = 0
@@ -222,6 +228,8 @@ class FileRunner:
             scope.metrics.pop(pid)
         if pid in scope.ctx_write_buf:
             scope.ctx_write_buf.pop(pid)
+        if pid in scope.contexts:
+            scope.contexts.pop(pid)
         epoch += 1
 
     def _respond(

--- a/python/coglet/file_runner.py
+++ b/python/coglet/file_runner.py
@@ -167,10 +167,10 @@ class FileRunner:
             'status': 'starting',
         }
         context_dict = {}
-        if "token" in resp:
-            context_dict["token"] = resp["token"]
-        if "procedure_source_url" in resp:
-            context_dict["procedure_source_url"] = resp["procedure_source_url"]
+        if 'token' in resp:
+            context_dict['token'] = resp['token']
+        if 'procedure_source_url' in resp:
+            context_dict['procedure_source_url'] = resp['procedure_source_url']
         scope.contexts[pid] = context_dict
         # Write partial response, e.g. starting, processing, if webhook is set
         is_async = 'webhook' in req

--- a/python/coglet/file_runner.py
+++ b/python/coglet/file_runner.py
@@ -167,10 +167,10 @@ class FileRunner:
             'status': 'starting',
         }
         context_dict = {}
-        if 'token' in resp:
-            context_dict['token'] = resp['token']
-        if 'procedure_source_url' in resp:
-            context_dict['procedure_source_url'] = resp['procedure_source_url']
+        if 'token' in req:
+            context_dict['token'] = req['token']
+        if 'procedure_source_url' in req:
+            context_dict['procedure_source_url'] = req['procedure_source_url']
         scope.contexts[pid] = context_dict
         # Write partial response, e.g. starting, processing, if webhook is set
         is_async = 'webhook' in req

--- a/python/coglet/scope.py
+++ b/python/coglet/scope.py
@@ -16,7 +16,6 @@ ctx_write_buf: Dict[str, str] = {}
 class Scope:
     def __init__(self, pid: str):
         self.pid = pid
-        self.context = defaultdict(dict)
 
     def record_metric(self, name: str, value: Any) -> None:
         metrics[self.pid][name] = value

--- a/python/coglet/scope.py
+++ b/python/coglet/scope.py
@@ -9,15 +9,25 @@ ctx_pid: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     'pid', default=None
 )
 metrics: Dict[str, Dict[str, Any]] = defaultdict(dict)
+contexts: Dict[str, Dict[str, Any]] = defaultdict(dict)
 ctx_write_buf: Dict[str, str] = {}
 
 
 class Scope:
     def __init__(self, pid: str):
         self.pid = pid
+        self.context = defaultdict(dict)
 
     def record_metric(self, name: str, value: Any) -> None:
         metrics[self.pid][name] = value
+
+    @property
+    def context(self) -> Dict[str, Any]:
+        return contexts[self.pid]
+
+    @context.setter
+    def context(self, value: Dict[str, Any]) -> None:
+        contexts[self.pid] = value
 
 
 # Compat: for internal model metrics

--- a/python/tests/procedures/bar/cog.yaml
+++ b/python/tests/procedures/bar/cog.yaml
@@ -1,0 +1,1 @@
+predict: "predict.py:predict"

--- a/python/tests/procedures/bar/predict.py
+++ b/python/tests/procedures/bar/predict.py
@@ -1,0 +1,7 @@
+import os
+
+
+def predict(i: int) -> str:
+    print('predicting bar')
+    token = os.environ.get('REPLICATE_API_TOKEN')
+    return f'i={i}, token={token}'

--- a/python/tests/procedures/bar/predict.py
+++ b/python/tests/procedures/bar/predict.py
@@ -1,7 +1,7 @@
-import os
+from cog import current_scope
 
 
 def predict(i: int) -> str:
     print('predicting bar')
-    token = os.environ.get('REPLICATE_API_TOKEN')
+    token = current_scope().context['token']
     return f'i={i}, token={token}'

--- a/python/tests/procedures/cog.yaml
+++ b/python/tests/procedures/cog.yaml
@@ -1,0 +1,1 @@
+predict: "predict.py:predict"

--- a/python/tests/procedures/foo/cog.yaml
+++ b/python/tests/procedures/foo/cog.yaml
@@ -1,0 +1,1 @@
+predict: "predict.py:predict"

--- a/python/tests/procedures/foo/predict.py
+++ b/python/tests/procedures/foo/predict.py
@@ -1,7 +1,7 @@
-import os
+from cog import current_scope
 
 
 def predict(s: str) -> str:
     print('predicting foo')
-    token = os.environ.get('REPLICATE_API_TOKEN')
+    token = current_scope().context['token']
     return f's={s}, token={token}'

--- a/python/tests/procedures/foo/predict.py
+++ b/python/tests/procedures/foo/predict.py
@@ -1,0 +1,7 @@
+import os
+
+
+def predict(s: str) -> str:
+    print('predicting foo')
+    token = os.environ.get('REPLICATE_API_TOKEN')
+    return f's={s}, token={token}'

--- a/script/cog-procedure.sh
+++ b/script/cog-procedure.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Run Cog HTTP server
+
+set -euo pipefail
+
+base_dir="$(git rev-parse --show-toplevel)"
+
+# PYTHON=1 to run with legacy Cog
+if [ -z "${PYTHON:-}" ]; then
+    export LOG_FORMAT=development
+    export PATH="$base_dir/.venv/bin:$PATH"
+    PYTHON_VERSION="$(cat "$base_dir/.python-version")"
+    export PYTHONPATH="$base_dir/python:$base_dir/.venv/lib/python$PYTHON_VERSION/site-packages"
+    args=()
+    if [ -n "${PORT:-}" ]; then
+        args+=(--port "$PORT")
+    fi
+    go run "$base_dir/cmd/cog/main.go" server "${args[@]}" --use-procedure-mode "$@"
+else
+    cd "$base_dir/../pipelines-runtime"
+    export PROCEDURE_CACHE_PATH=/tmp/procedures
+    "$base_dir/.venv-procedure/bin/python3" -m cog.server.http "$@"
+fi

--- a/script/init.sh
+++ b/script/init.sh
@@ -15,3 +15,11 @@ uv venv --python 3.13 .venv-legacy
 export VIRTUAL_ENV="$base_dir/.venv-legacy"
 export UV_PROJECT_ENVIRONMENT="$VIRTUAL_ENV"
 uv pip install cog==0.14.3
+
+# venv with pipelines
+if [ -d ../pipelines-runtime ]; then
+    uv venv --python 3.13 .venv-procedure
+    export VIRTUAL_ENV="$base_dir/.venv-procedure"
+    export UV_PROJECT_ENVIRONMENT="$VIRTUAL_ENV"
+    uv pip install ../pipelines-runtime
+fi


### PR DESCRIPTION
Rework of #74 to maximize reuse of the go `Runner` & add integration test.

* Right now only 1 active procedure. New request with a different procedure URL will stop the current runner (gracefully, so it will finish pending requests and send web hooks) and replace it with the new one.
* Integration test with legacy cog requires the private `pipelines-runtime` to be checked out into a sibling directory. So it's skipped right now in CI.
* Now that we're no longer using a fake wrapper model, can we move `procedure_source_url` & `token` to prediction request top level, and keep original `input` as is instead of JSON in JSON?
  `{"procedure_source_url": "file://tmp/x", "token": "foo", "input": {"s": "hello"}}`
* Found 2 issues with legacy Cog:
  * Bug where logs from different procedures are mixed up, possibly a concurrency bug. Non-issue here since user code log lines are prefixed with prediction ID.
  * Pickle error, again non-issue here because no multiprocessing, no IPC, no pickle.