### PR TITLE
Add logs from subprocesses

### DIFF
--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -533,8 +533,28 @@ func (r *Runner) log(line string) {
 	} else if !strings.Contains(line, "[coglet]") {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		r.logs = append(r.logs, line)
-		r.setupResult.Logs = util.JoinLogs(r.logs)
+		if r.setupResult.CompletedAt != "" {
+			// Anything from inside would be a subprocess call. If it's an async
+			// prediction though, we have no clue who's process is who's - this
+			// can lead to us leaking outputs from one user to another so we
+			// shouldn't keep the lines here
+			if len(r.pending) > 1 {
+				log.Errorw("expected only 1 prediction to be running", "num_running", len(r.pending))
+			} else {
+				for pid := range r.pending {
+					pr := r.pending[pid]
+					fmt.Printf("Line: %s\n", line)
+					pr.appendLogLine(line)
+					// In case log is received before "starting" response
+					if pr.response.Status != "" {
+						pr.sendWebhook(WebhookLogs)
+					}
+				}
+			}
+		} else {
+			r.logs = append(r.logs, line)
+			r.setupResult.Logs = util.JoinLogs(r.logs)
+		}
 	}
 	fmt.Println(line)
 }


### PR DESCRIPTION
### Summary

Add logs from subprocesses, only if in blocking mode

### Test Plan

Run `./script/cog-predict.sh path` with the following modification
```
diff --git a/python/tests/runners/path.py b/python/tests/runners/path.py
index 479376f..f9d8eb1 100644
--- a/python/tests/runners/path.py
+++ b/python/tests/runners/path.py
@@ -1,5 +1,7 @@
 import tempfile
 import time
+import subprocess
+import sys
 
 from cog import BasePredictor, Path
 
@@ -9,6 +11,7 @@ class Predictor(BasePredictor):
 
     def predict(self, p: Path) -> Path:
         time.sleep(0.1)
+        subprocess.run(["echo", "hello"], check=True)
         with open(p, 'r') as f:
             print('reading input file')
             s = f.read()

```
In the output logs you should see
```
"logs":"hello\nreading input file\nwriting output file\n"
```