### PR TITLE
Prepare procedure source URL for remote tarballs

### DIFF
--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -119,21 +118,10 @@ func NewRunner(awaitExplicitShutdown bool, uploadUrl string) *Runner {
 	}
 }
 
-func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string, u *url.URL) (*Runner, error) {
-	err := os.Mkdir(srcDir, 0o755)
-	if err != nil {
-		return nil, err
-	}
-	if u != nil {
-		cmd := exec.Command("pget", u.String(), srcDir, "-x")
-		err = cmd.Run()
-		if err != nil {
-			return nil, err
-		}
-	}
+func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string) *Runner {
 	r := NewRunner(awaitExplicitShutdown, uploadUrl)
 	r.cmd.Dir = srcDir
-	return r, nil
+	return r
 }
 
 func (r *Runner) SrcDir() string {

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -120,6 +120,7 @@ func NewRunner(awaitExplicitShutdown bool, uploadUrl string) *Runner {
 
 func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string) *Runner {
 	r := NewRunner(awaitExplicitShutdown, uploadUrl)
+	os.Mkdir(srcDir, 0o755)
 	r.cmd.Dir = srcDir
 	return r
 }

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -118,11 +119,21 @@ func NewRunner(awaitExplicitShutdown bool, uploadUrl string) *Runner {
 	}
 }
 
-func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string) *Runner {
+func NewProcedureRunner(awaitExplicitShutdown bool, uploadUrl string, srcDir string, u *url.URL) (*Runner, error) {
+	err := os.Mkdir(srcDir, 0o755)
+	if err != nil {
+		return nil, err
+	}
+	if u != nil {
+		cmd := exec.Command("pget", u.String(), srcDir, "-x")
+		err = cmd.Run()
+		if err != nil {
+			return nil, err
+		}
+	}
 	r := NewRunner(awaitExplicitShutdown, uploadUrl)
-	os.Mkdir(srcDir, 0o755)
 	r.cmd.Dir = srcDir
-	return r
+	return r, nil
 }
 
 func (r *Runner) SrcDir() string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,15 +1,12 @@
 package server
 
 import (
-	"crypto/md5"
 	_ "embed"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"sync"
 	"syscall"
 	"time"
@@ -123,7 +120,7 @@ func (h *Handler) Shutdown(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) updateRunner(srcDir, token string, u *url.URL) error {
+func (h *Handler) updateRunner(srcDir, token string) error {
 	log := logger.Sugar()
 
 	// Reuse current runner, nothing to do
@@ -200,14 +197,11 @@ func (h *Handler) Predict(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "missing procedure_source_url or token", http.StatusBadRequest)
 			return
 		}
-		u, err := url.Parse(req.ProcedureSourceURL)
+		srcDir, err := util.PrepareProcedureSourceURL(req.ProcedureSourceURL)
 		if err != nil {
 			http.Error(w, "invalid procedure_source_url", http.StatusBadRequest)
-			return
 		}
-		hash := md5.Sum([]byte(u.Path))
-		srcDir := hex.EncodeToString(hash[:])
-		if err := h.updateRunner(srcDir, req.Token, u); err != nil {
+		if err := h.updateRunner(srcDir, req.Token); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"crypto/md5"
 	_ "embed"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -203,7 +205,8 @@ func (h *Handler) Predict(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid procedure_source_url", http.StatusBadRequest)
 			return
 		}
-		srcDir := u.Path
+		hash := md5.Sum([]byte(u.Path))
+		srcDir := hex.EncodeToString(hash[:])
 		if err := h.updateRunner(srcDir, req.Token); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,7 +123,7 @@ func (h *Handler) Shutdown(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) updateRunner(srcDir, token string) error {
+func (h *Handler) updateRunner(srcDir, token string, u *url.URL) error {
 	log := logger.Sugar()
 
 	// Reuse current runner, nothing to do
@@ -207,7 +207,7 @@ func (h *Handler) Predict(w http.ResponseWriter, r *http.Request) {
 		}
 		hash := md5.Sum([]byte(u.Path))
 		srcDir := hex.EncodeToString(hash[:])
-		if err := h.updateRunner(srcDir, req.Token); err != nil {
+		if err := h.updateRunner(srcDir, req.Token, u); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/tests/procedure_url_test.go
+++ b/internal/tests/procedure_url_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/replicate/go/must"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/replicate/cog-runtime/internal/util"
+)
+
+var proceduresPath = filepath.Join(basePath, "python", "tests", "procedures")
+
+func TestPrepareProcedureSourceURLLocal(t *testing.T) {
+	badDir, err := util.PrepareProcedureSourceURL("file:///foo/bar")
+	assert.ErrorContains(t, err, "no such file or directory")
+	assert.Empty(t, badDir)
+
+	fooDir := filepath.Join(proceduresPath, "foo")
+	srcDir := fmt.Sprintf("file://%s", fooDir)
+	fooDst, err := util.PrepareProcedureSourceURL(srcDir)
+	assert.NoError(t, err)
+	assert.Equal(t, fooDir, fooDst)
+}
+
+func TestPrepareProcedureSourceURLRemote(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	fooTar := filepath.Join(tmpDir, "foo.tar.gz")
+	fooDir := filepath.Join(proceduresPath, "foo")
+	must.Do(exec.Command("tar", "-czf", fooTar, "-C", fooDir, ".").Run())
+
+	barTar := filepath.Join(tmpDir, "bar.tar.gz")
+	barDir := filepath.Join(proceduresPath, "bar")
+	must.Do(exec.Command("tar", "-czf", barTar, "-C", barDir, ".").Run())
+
+	port := util.FindPort()
+	s := http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: http.FileServer(http.Dir(tmpDir)),
+	}
+	defer s.Shutdown(context.Background())
+	go func() {
+		s.ListenAndServe()
+	}()
+
+	fooDst, err := util.PrepareProcedureSourceURL(fmt.Sprintf("http://localhost:%d/foo.tar.gz", port))
+	assert.NoError(t, err)
+	assert.DirExists(t, fooDst)
+	assert.FileExists(t, filepath.Join(fooDst, "cog.yaml"))
+	fooPy := filepath.Join(fooDst, "predict.py")
+	assert.FileExists(t, fooPy)
+	assert.Contains(t, string(must.Get(os.ReadFile(fooPy))), "'predicting foo'")
+
+	barDst, err := util.PrepareProcedureSourceURL(fmt.Sprintf("http://localhost:%d/bar.tar.gz", port))
+	assert.NoError(t, err)
+	assert.DirExists(t, barDst)
+	assert.FileExists(t, filepath.Join(barDst, "cog.yaml"))
+	barPy := filepath.Join(barDst, "predict.py")
+	assert.FileExists(t, barPy)
+	assert.Contains(t, string(must.Get(os.ReadFile(barPy))), "'predicting bar'")
+
+	fooDst2, err := util.PrepareProcedureSourceURL(fmt.Sprintf("http://localhost:%d/foo.tar.gz", port))
+	assert.NoError(t, err)
+	assert.Equal(t, fooDst2, fooDst)
+
+	barDst2, err := util.PrepareProcedureSourceURL(fmt.Sprintf("http://localhost:%d/bar.tar.gz", port))
+	assert.NoError(t, err)
+	assert.Equal(t, barDst2, barDst)
+}

--- a/internal/util/find_port.go
+++ b/internal/util/find_port.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"net"
+	"sync"
+
+	"github.com/replicate/go/must"
+)
+
+var (
+	ports   = make(map[int]bool)
+	portsMu sync.Mutex
+)
+
+type PortFinder struct {
+	ports map[int]bool
+	mu    sync.Mutex
+}
+
+func FindPort() int {
+	portsMu.Lock()
+	defer portsMu.Unlock()
+	for {
+		a := must.Get(net.ResolveTCPAddr("tcp", "localhost:0"))
+		l := must.Get(net.ListenTCP("tcp", a))
+		p := l.Addr().(*net.TCPAddr).Port
+		if _, ok := ports[p]; !ok {
+			ports[p] = true
+			l.Close()
+			return p
+		}
+	}
+}

--- a/internal/util/procedure.go
+++ b/internal/util/procedure.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func PrepareProcedureSourceURL(srcURL string) (string, error) {
+	u, err := url.Parse(srcURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "file" {
+		// file:///path/to/existing/dir
+		stat, err := os.Stat(u.Path)
+		if err != nil {
+			return "", err
+		}
+		if !stat.IsDir() {
+			return "", fmt.Errorf("invalid procedure source URL: %s", srcURL)
+		}
+		return u.Path, nil
+	} else if u.Scheme == "http" || u.Scheme == "https" {
+		// http://host/path/to/tarball
+		sha := sha256.New()
+		sha.Write([]byte(srcURL))
+		hash := hex.EncodeToString(sha.Sum(nil))
+		dstDir := filepath.Join(os.TempDir(), fmt.Sprintf("procedure-%s", hash))
+
+		// Already downloaded
+		stat, err := os.Stat(dstDir)
+		if err == nil && stat.IsDir() {
+			return dstDir, nil
+		}
+
+		// Download to temporary file
+		// tar -xf cannot detect compression from stdin and file should be small enough
+		resp, err := http.Get(srcURL)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		tarball, err := os.CreateTemp("", fmt.Sprintf("procedure-%s-*", hash))
+		if err != nil {
+			return "", err
+		}
+		if _, err := io.Copy(tarball, resp.Body); err != nil {
+			return "", err
+		}
+		defer os.Remove(tarball.Name())
+
+		// Extract tarball
+		if err := os.MkdirAll(dstDir, 0o700); err != nil {
+			return "", err
+		}
+		cmd := exec.Command("tar", "-xf", tarball.Name(), "-C", dstDir)
+		if err := cmd.Run(); err != nil {
+			return "", err
+		}
+		return dstDir, nil
+	}
+	return "", fmt.Errorf("invalid procedure source URL: %s", srcURL)
+}


### PR DESCRIPTION
* If someone has a URL path for a procedure that contains multiple directories this currently fail
* Hash the path so the directories are standardised