### PR TITLE
Use `replicate_api_token` instead of `token`

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,7 +120,7 @@ func (h *Handler) Shutdown(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) updateRunner(srcDir, token string) error {
+func (h *Handler) updateRunner(srcDir string) error {
 	log := logger.Sugar()
 
 	// Reuse current runner, nothing to do
@@ -200,22 +200,22 @@ func (h *Handler) Predict(w http.ResponseWriter, r *http.Request) {
 		}
 		procedureSourceUrl := val.(string)
 
-		val, ok = req.Context["token"]
+		val, ok = req.Context["replicate_api_token"]
 		if !ok {
-			http.Error(w, "missing token in context", http.StatusBadRequest)
+			http.Error(w, "missing replicate_api_token in context", http.StatusBadRequest)
 			return
 		}
 
 		token := val.(string)
 		if procedureSourceUrl == "" || token == "" {
-			http.Error(w, "empty procedure_source_url or token", http.StatusBadRequest)
+			http.Error(w, "empty procedure_source_url or replicate_api_token", http.StatusBadRequest)
 			return
 		}
 		srcDir, err := util.PrepareProcedureSourceURL(procedureSourceUrl)
 		if err != nil {
 			http.Error(w, "invalid procedure_source_url", http.StatusBadRequest)
 		}
-		if err := h.updateRunner(srcDir, token); err != nil {
+		if err := h.updateRunner(srcDir); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = []
 dev = [
     'build',
     'ipython',
-    'mypy',
+    'mypy==1.16.0', # pinned to fix CI
     'setuptools',
 ]
 

--- a/python/coglet/file_runner.py
+++ b/python/coglet/file_runner.py
@@ -170,12 +170,12 @@ class FileRunner:
         if 'context' in req:
             context = req['context']
             if context is not None:
-                if 'token' in context:
-                    context_dict['replicate_api_token'] = context['token']
                 if 'procedure_source_url' in context:
                     context_dict['procedure_source_url'] = context[
                         'procedure_source_url'
                     ]
+                if 'replicate_api_token' in context:
+                    context_dict['replicate_api_token'] = context['replicate_api_token']
         scope.contexts[pid] = context_dict
         # Write partial response, e.g. starting, processing, if webhook is set
         is_async = 'webhook' in req


### PR DESCRIPTION
This PR renames the `token` key in the prediction request context to `replicate_api_token`. Ultimately I don't think this is needed at all, the context just needs to be passed along and made available via the `current_scope().context`. But this is the smallest change to get us unblocked.
