### PR TITLE
Support predictors returning `os.PathLike` instances

### DIFF
--- a/python/coglet/adt.py
+++ b/python/coglet/adt.py
@@ -1,6 +1,6 @@
-import os
 import dataclasses
 import inspect
+import os
 import typing
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -58,8 +58,12 @@ class PrimitiveType(Enum):
         if match := PrimitiveType._adt_type().get(tpe):
             return match
 
-        if tpe is os.PathLike or issubclass(tpe, os.PathLike):
-            return PrimitiveType.PATH
+        try:
+            if tpe is os.PathLike or issubclass(tpe, os.PathLike):
+                return PrimitiveType.PATH
+        except TypeError:
+            # Catch arg 1 is not a class in issubclass
+            pass
 
         return PrimitiveType.CUSTOM
 

--- a/python/coglet/adt.py
+++ b/python/coglet/adt.py
@@ -1,3 +1,4 @@
+import os
 import dataclasses
 import inspect
 import typing
@@ -54,7 +55,13 @@ class PrimitiveType(Enum):
 
     @staticmethod
     def from_type(tpe: type) -> Any:
-        return PrimitiveType._adt_type().get(tpe, PrimitiveType.CUSTOM)
+        if match := PrimitiveType._adt_type().get(tpe):
+            return match
+
+        if tpe is os.PathLike or issubclass(tpe, os.PathLike):
+            return PrimitiveType.PATH
+
+        return PrimitiveType.CUSTOM
 
     def normalize(self, value: Any) -> Any:
         pt = PrimitiveType._python_type()[self]

--- a/python/coglet/util.py
+++ b/python/coglet/util.py
@@ -1,4 +1,6 @@
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 
 from coglet import api
 
@@ -11,9 +13,9 @@ def now_iso() -> str:
 # Encode JSON for file_runner output
 def output_json(obj):
     tpe = type(obj)
-    if tpe is api.Path:
+    if isinstance(obj, os.PathLike):
         # Prefix protocol for uploader
-        return obj.absolute().as_uri()
+        return Path(obj).absolute().as_uri()
     elif tpe is api.Secret:
         # Encode Secret('foobar') as '**********'
         return str(obj)

--- a/python/tests/schemas/output_pathlike.json
+++ b/python/tests/schemas/output_pathlike.json
@@ -1,0 +1,401 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Cog",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/shutdown": {
+      "post": {
+        "summary": "Start Shutdown",
+        "operationId": "start_shutdown_shutdown_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Start Shutdown Shutdown Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Root  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health-check": {
+      "get": {
+        "summary": "Healthcheck",
+        "operationId": "healthcheck_health_check_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Healthcheck Health Check Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions": {
+      "post": {
+        "summary": "Predict",
+        "description": "Run a single prediction on the model",
+        "operationId": "predict_predictions_post",
+        "parameters": [
+          {
+            "name": "prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Prefer",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}": {
+      "put": {
+        "summary": "Predict Idempotent",
+        "description": "Run a single prediction on the model (idempotent creation).",
+        "operationId": "predict_idempotent_predictions__prediction_id__put",
+        "parameters": [
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            }
+          },
+          {
+            "name": "prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Prefer",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PredictionRequest"
+                  }
+                ],
+                "title": "Prediction Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}/cancel": {
+      "post": {
+        "summary": "Cancel",
+        "description": "Cancel a running prediction",
+        "operationId": "cancel_predictions__prediction_id__cancel_post",
+        "parameters": [
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Cancel Predictions  Prediction Id  Cancel Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Input": {
+        "properties": {
+          "x": {
+            "type": "string",
+            "format": "uri",
+            "title": "X",
+            "x-order": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "x"
+        ],
+        "title": "Input"
+      },
+      "Output": {
+        "type": "string",
+        "format": "uri",
+        "title": "Output"
+      },
+      "PredictionRequest": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string",
+            "format": "date-time"
+          },
+          "output_file_prefix": {
+            "title": "Output File Prefix",
+            "type": "string"
+          },
+          "webhook": {
+            "title": "Webhook",
+            "type": "string",
+            "maxLength": 65536,
+            "minLength": 1,
+            "format": "uri"
+          },
+          "webhook_events_filter": {
+            "default": [
+              "start",
+              "output",
+              "logs",
+              "completed"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/WebhookEvent"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "title": "PredictionRequest"
+      },
+      "PredictionResponse": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input"
+          },
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string",
+            "format": "date-time"
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string",
+            "format": "date-time"
+          },
+          "completed_at": {
+            "title": "Completed At",
+            "type": "string",
+            "format": "date-time"
+          },
+          "logs": {
+            "type": "string",
+            "title": "Logs",
+            "default": ""
+          },
+          "error": {
+            "title": "Error",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/Status"
+          },
+          "metrics": {
+            "title": "Metrics",
+            "type": "object"
+          }
+        },
+        "type": "object",
+        "title": "PredictionResponse"
+      },
+      "Status": {
+        "type": "string",
+        "enum": [
+          "starting",
+          "processing",
+          "succeeded",
+          "canceled",
+          "failed"
+        ],
+        "title": "Status",
+        "description": "An enumeration."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WebhookEvent": {
+        "type": "string",
+        "enum": [
+          "start",
+          "output",
+          "logs",
+          "completed"
+        ],
+        "title": "WebhookEvent",
+        "description": "An enumeration."
+      }
+    }
+  }
+}

--- a/python/tests/schemas/output_pathlike.py
+++ b/python/tests/schemas/output_pathlike.py
@@ -1,0 +1,32 @@
+import os
+
+from cog import BasePredictor, Path
+
+
+class MyPath(os.PathLike):
+    def __init__(self, path: str) -> None:
+        # Store path components internally
+        self._path = path
+
+    def __fspath__(self) -> str:
+        # Build and return a string path
+        return self._path
+
+    def __repr__(self) -> str:
+        return f'MyPath({self._path!r})'
+
+
+FIXTURE = [
+    ({'x': 'foo.txt'}, Path('/tmp/foo.txt')),
+    ({'x': Path('bar.txt')}, Path('/tmp/bar.txt')),
+]
+
+
+class Predictor(BasePredictor):
+    setup_done = False
+
+    def setup(self) -> None:
+        self.setup_done = True
+
+    def predict(self, x: Path) -> MyPath:
+        return MyPath(f'/tmp/{x}')


### PR DESCRIPTION
This will ensure that it supports anything that conforms to `os.PathLike` including `pathlib.PosixPath`.