### PR TITLE
Handle Status Created when uploading

### DIFF
--- a/internal/server/path.go
+++ b/internal/server/path.go
@@ -215,7 +215,7 @@ func outputToUpload(uploadUrl string, predictionId string) func(s string, paths 
 			return "", err
 		}
 		resp.Body.Close()
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 			return "", fmt.Errorf("failed to upload file: status %s", resp.Status)
 		}
 		return resp.Header.Get("Location"), nil


### PR DESCRIPTION
* Seeing the following when running `cog-runtime` on pipelines:

```│ {"severity":"error","timestamp":"2025-06-16T18:58:42.987Z","logger":"cog-http-server","caller":"server/runner.go:487","message":"failed to handle output","id":"t0m3g8d139rma0cqf8dt6679kr","error":"failed to upload file: status 201 Created","stacktrace":"github.com/replicate/cog-runtime/internal/server.(*Runner).handleResponses\n\t/home/runner/work/cog-runtime/cog-runtime/ │
│ internal/server/runner.go:487\ngithub.com/replicate/cog-runtime/internal/server.(*Runner).handleSignals\n\t/home/runner/work/cog-runtime/cog-runtime/internal/server/runner.go:370"}```

Assume this is due to not handling HTTP `201` on upload.