### PR TITLE
Check default=None only in schema command

### DIFF
--- a/python/coglet/inspector.py
+++ b/python/coglet/inspector.py
@@ -327,7 +327,9 @@ def _find_coders(module: ModuleType) -> None:
         )
 
 
-def create_predictor(module_name: str, predictor_name: str) -> adt.Predictor:
+def create_predictor(
+    module_name: str, predictor_name: str, inspect_ast: bool = False
+) -> adt.Predictor:
     module = importlib.import_module(module_name)
     fullname = f'{module_name}.{predictor_name}'
     assert hasattr(module, predictor_name), f'predictor not found: {fullname}'
@@ -354,7 +356,9 @@ def create_predictor(module_name: str, predictor_name: str) -> adt.Predictor:
     predictor = _predictor_adt(module_name, predictor_name, predict_fn, is_class_fn)
 
     # AST checks at the end after all other checks pass
-    if module.__file__ is not None:
+    # Only check when running from cog.command.openapi_schema -> coglet.schema
+    # So that old models that violate this check can still run
+    if inspect_ast and module.__file__ is not None:
         asts.inspect(module.__file__)
 
     return predictor

--- a/python/coglet/schema.py
+++ b/python/coglet/schema.py
@@ -29,7 +29,7 @@ def main():
         # - Bad dependencies
         # - Bad input/output types
         # - Libraries downloading weights on init
-        p = inspector.create_predictor(sys.argv[1], sys.argv[2])
+        p = inspector.create_predictor(sys.argv[1], sys.argv[2], inspect_ast=True)
 
         # Check that test_inputs exists and is valid
         module = importlib.import_module(p.module_name)

--- a/python/tests/test_bad_predictor.py
+++ b/python/tests/test_bad_predictor.py
@@ -20,7 +20,7 @@ def run(module_name: str, predictor_name: str) -> None:
         m = importlib.import_module(module_name)
         err_msg = getattr(m, 'ERROR')
         with pytest.raises(AssertionError, match=re.escape(err_msg)):
-            inspector.create_predictor(module_name, predictor_name)
+            inspector.create_predictor(module_name, predictor_name, inspect_ast=True)
     except PythonVersionError as e:
         pytest.skip(reason=str(e))
 


### PR DESCRIPTION
We have existing models that violate this check. So only enable this
check in schema command which is called during cog build.
