### PR TITLE
Set UID in procedure Python runners for FS isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,19 @@ jobs:
       - run: ./script/init.sh
       - run: ./script/test.sh go -legacy-cog
 
+  test-set-uid:
+    name: Test Set UID for procedure mode
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v6
+      - run: ./script/init.sh
+      - run: ./script/test-setuid.sh
+
   build-python:
     name: Build & verify python package
     runs-on: ubuntu-latest

--- a/python/coglet/__main__.py
+++ b/python/coglet/__main__.py
@@ -57,6 +57,9 @@ def main() -> int:
     parser.add_argument(
         '--working-dir', metavar='DIR', required=True, help='working directory'
     )
+    parser.add_argument(
+        '--set-uid', metavar='UID', type=int, default=0, help='set UID on startup'
+    )
 
     logger = logging.getLogger('coglet')
     logger.setLevel(logging.INFO)
@@ -75,6 +78,11 @@ def main() -> int:
     sys.stderr.write = scope.ctx_write(_stderr_write)  # type: ignore
 
     args = parser.parse_args()
+
+    if args.set_uid != 0:
+        logger.info('setting UID to %d', args.set_uid)
+        os.setgid(65534)  # nogroup
+        os.setuid(args.set_uid)
 
     config = pre_setup(logger, args.working_dir)
     if config is None:

--- a/python/coglet/file_runner.py
+++ b/python/coglet/file_runner.py
@@ -56,7 +56,6 @@ class FileRunner:
             self.config.max_concurrency,
         )
 
-        os.makedirs(self.working_dir, exist_ok=True)
         setup_result_file = os.path.join(self.working_dir, 'setup_result.json')
         stop_file = os.path.join(self.working_dir, 'stop')
         openapi_file = os.path.join(self.working_dir, 'openapi.json')

--- a/python/tests/procedures/setuid/cog.yaml
+++ b/python/tests/procedures/setuid/cog.yaml
@@ -1,0 +1,1 @@
+predict: "predict.py:predict"

--- a/python/tests/procedures/setuid/predict.py
+++ b/python/tests/procedures/setuid/predict.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+
+BASE_UID = 9000
+NOGROUP_GID = 65534
+
+
+def predict(s: str) -> str:
+    uid = os.getuid()
+    gid = os.getgid()
+    print(f'UID={uid}')
+    print(f'GID={gid}')
+    assert uid >= BASE_UID
+    assert gid == NOGROUP_GID
+
+    # CWD is a "copy" of the procedure source
+    # where directories are created with UID/GID
+    # while files are symlinked
+    cwd = os.getcwd()
+    print(f'CWD={cwd}')
+    stat = os.stat(cwd)
+    assert stat.st_uid == uid
+    assert stat.st_gid == gid
+
+    with open('out.txt', 'w') as f:
+        print(f'writing to file: {f.name}')
+        f.write('out')
+
+    tmpdir = os.environ.get('TMPDIR')
+    print(f'TMPDIR={tmpdir}')
+    assert tmpdir is not None
+    assert tmpdir.startswith('/tmp/cog-runner-tmp-')
+    stat = os.stat(tmpdir)
+    assert stat.st_uid == uid
+    assert stat.st_gid == gid
+
+    with tempfile.NamedTemporaryFile(mode='w+') as f:
+        print(f'writing to file: {f.name}')
+        f.write('out')
+
+    return s

--- a/script/test-setuid.sh
+++ b/script/test-setuid.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Unit tests
+
+set -euo pipefail
+
+base_dir="$(git rev-parse --show-toplevel)"
+port=${PORT:-5000}
+
+cd "$base_dir"
+
+./script/build.sh
+
+name="test-setuid-$(date '+%s')"
+docker run -it --rm --detach \
+    --name "$name" \
+    --entrypoint /bin/bash \
+    --publish "$port:$port" \
+    --volume "$PWD":/src python:latest \
+    -c "find /src/dist -name '*.whl' -exec pip install {} \; && python3 -m cog.server.http --port $port --use-procedure-mode"
+
+sleep 3  # wait for server startup
+resp="$(mktemp)"
+trap 'rm $resp; docker stop $name' EXIT
+curl -fsSL -X POST \
+    -H 'Content-Type: application/json' \
+    --data '{"context":{"procedure_source_url": "file:///src/python/tests/procedures/setuid", "replicate_api_token": "token"}, "input":{"s":"hello"}}' \
+    "http://localhost:$port/procedures" > "$resp"
+
+status="$(jq --raw-output '.status' < "$resp")"
+if [ "$status" != "succeeded" ]; then
+    echo "Docker logs:"
+    docker logs "$name"
+    echo
+    echo "Response:"
+    cat "$resp"
+    echo
+    echo "FAILED"
+    exit 1
+else
+    echo "Docker logs:"
+    docker logs "$name"
+    echo
+    echo "PASSED"
+fi


### PR DESCRIPTION
To achieve some best effort FS isolation:
* Set Python runner process to UID 5000+n & GID 65534 (nogroup), where n is `[0, max_runners)`
* When copying procedure source, change directory owners so that they're writable by the runner, while keeping `root` as symlink owner so that they're read-only
* Change `working-dir` (request & response JSON flies) owner so that the runner can write or delete them
* Create per slot `TMPDIR` and change owner, this should affect any library that respects the env, e.g. `mktemp`, `tempfile`