### PR TITLE
Fix output Iterator[Path] case

### DIFF
--- a/python/tests/runners/path_out_iter.py
+++ b/python/tests/runners/path_out_iter.py
@@ -1,0 +1,18 @@
+import tempfile
+import time
+from typing import Iterator
+
+from cog import BasePredictor, Path
+
+
+class Predictor(BasePredictor):
+    test_inputs = {'n': 2}
+
+    def predict(self, n: int) -> Iterator[Path]:
+        for i in range(n):
+            time.sleep(1)
+            with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.txt', delete=False
+            ) as f:
+                f.write(f'out{i}')
+            yield Path(f.name)


### PR DESCRIPTION
We delete an output file immediately after uploading. So in the cast of `Iterator[Path]`, we can get the following JSON response after each `yield path`:
* `["out1.txt"]` -> upload & delete
* `["out1.txt", "out2.txt"]` -> `out1.txt` already deleted, error