### PR TITLE
Pipe Python stdout/stderr to the same streams in Go

### DIFF
--- a/internal/tests/cog_test.go
+++ b/internal/tests/cog_test.go
@@ -139,13 +139,17 @@ func (ct *CogTest) AppendEnvs(envs ...string) {
 }
 
 func (ct *CogTest) Start() error {
+	return ct.StartWithPipes(os.Stdout, os.Stderr)
+}
+
+func (ct *CogTest) StartWithPipes(stdout, stderr io.Writer) error {
 	if *legacyCog {
 		ct.cmd = ct.legacyCmd()
 	} else {
 		ct.cmd = ct.runtimeCmd()
 	}
-	ct.cmd.Stdout = os.Stdout
-	ct.cmd.Stderr = os.Stderr
+	ct.cmd.Stdout = stdout
+	ct.cmd.Stderr = stderr
 	return ct.cmd.Start()
 }
 

--- a/internal/tests/logs_test.go
+++ b/internal/tests/logs_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/replicate/cog-runtime/internal/server"
+)
+
+func TestLogs(t *testing.T) {
+	ct := NewCogTest(t, "logs")
+	// Replicate Go logger logs to stdout in production mode
+	ct.AppendEnvs("LOG_FILE=stderr")
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	assert.NoError(t, ct.StartWithPipes(stdout, stderr))
+
+	hc := ct.WaitForSetup()
+	assert.Equal(t, server.StatusReady.String(), hc.Status)
+	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
+	hcLogs := "STDOUT: starting setup\nSTDERR: starting setup\nSTDOUT: completed setup\nSTDERR: completed setup\n"
+	assert.Equal(t, hcLogs, hc.Setup.Logs)
+
+	resp := ct.Prediction(map[string]any{"s": "bar"})
+	logs := "STDOUT: starting prediction\nSTDERR: starting prediction\nSTDOUT: completed prediction\nSTDERR: completed prediction\n"
+	ct.AssertResponse(resp, server.PredictionSucceeded, "*bar*", logs)
+
+	ct.Shutdown()
+	assert.NoError(t, ct.Cleanup())
+
+	sout := "STDOUT: starting setup\nSTDOUT: completed setup\nSTDOUT: starting prediction\nSTDOUT: completed prediction\n"
+	assert.Equal(t, sout, stdout.String())
+	stderrLines := strings.Split(stderr.String(), "\n")
+	assert.Contains(t, stderrLines, "STDERR: starting setup")
+	assert.Contains(t, stderrLines, "STDERR: completed setup")
+	assert.Contains(t, stderrLines, "STDERR: starting prediction")
+	assert.Contains(t, stderrLines, "STDERR: completed prediction")
+}

--- a/python/cog/command/go_cog.py
+++ b/python/cog/command/go_cog.py
@@ -25,4 +25,9 @@ def run(subcmd: str, args: List[str]) -> None:
     cmd = f'cog-{goos}-{goarch}'
     exe = os.path.join(Path(__file__).parent.parent, cmd)
     args = [exe, subcmd] + args
-    os.execv(exe, args)
+    # Replicate Go logger logs to stdout in production mode
+    # Use stderr instead to be consistent with legacy Cog
+    env = os.environ.copy()
+    if 'LOG_FILE' not in env:
+        env['LOG_FILE'] = 'stderr'
+    os.execve(exe, args, env)

--- a/python/coglet/__main__.py
+++ b/python/coglet/__main__.py
@@ -63,7 +63,7 @@ def main() -> int:
 
     logger = logging.getLogger('coglet')
     logger.setLevel(logging.INFO)
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(
         logging.Formatter(
             '%(asctime)s\t%(levelname)s\t[%(name)s]\t%(filename)s:%(lineno)d\t%(message)s'

--- a/python/tests/runners/logs.py
+++ b/python/tests/runners/logs.py
@@ -1,0 +1,27 @@
+import sys
+import time
+
+from cog import BasePredictor
+
+
+class Predictor(BasePredictor):
+    test_inputs = {'s': 'foo'}
+
+    def setup(self) -> None:
+        print('STDOUT: starting setup')
+        time.sleep(0.1)
+        print('STDERR: starting setup', file=sys.stderr)
+        time.sleep(0.1)
+        print('STDOUT: completed setup')
+        time.sleep(0.1)
+        print('STDERR: completed setup', file=sys.stderr)
+
+    def predict(self, s: str) -> str:
+        print('STDOUT: starting prediction')
+        time.sleep(0.1)
+        print('STDERR: starting prediction', file=sys.stderr)
+        time.sleep(0.1)
+        print('STDOUT: completed prediction')
+        time.sleep(0.1)
+        print('STDERR: completed prediction', file=sys.stderr)
+        return f'*{s}*'


### PR DESCRIPTION
Pipe stdout/stderr of the Python runner process to corresponding streams of the Go process.
Also override `LOG_FILE=stderr` so that it matches legacy Cog logging behavior.