### PR TITLE
Copy procedure dir instead of symlink

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -338,17 +338,13 @@ func (h *Handler) predictWithRunner(srcURL string, req PredictionRequest) (chan 
 	}
 	uid := BaseUID + slot
 	if h.setUID {
-		// PrepareProcedureSourceURL creates new directories but symlink files
-		// Change owner of directories only so they are writable
-		// But keep root as owner of symlinks so they are read-only
+		// PrepareProcedureSourceURL copies all directories and files
+		// Change ownership to unprivileged user
 		err = filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if d.IsDir() {
-				return os.Lchown(path, uid, NoGroupGID)
-			}
-			return nil
+			return os.Lchown(path, uid, NoGroupGID)
 		})
 		if err != nil {
 			return nil, err

--- a/script/test-setuid.sh
+++ b/script/test-setuid.sh
@@ -12,19 +12,31 @@ cd "$base_dir"
 ./script/build.sh
 
 name="test-setuid-$(date '+%s')"
+read -r -d '' SCRIPT << EOF || :
+set -e
+
+# Procedure source URLs in production might be readable by root only
+# So symlink won't work after dropping privilege
+cp -r /src/python/tests/procedures /
+chmod 700 /procedures/setuid
+chmod 600 /procedures/setuid/*
+
+find /src/dist -name '*.whl' -exec pip install {} \;
+python3 -m cog.server.http --port $port --use-procedure-mode
+EOF
 docker run -it --rm --detach \
     --name "$name" \
     --entrypoint /bin/bash \
     --publish "$port:$port" \
     --volume "$PWD":/src python:latest \
-    -c "find /src/dist -name '*.whl' -exec pip install {} \; && python3 -m cog.server.http --port $port --use-procedure-mode"
+    -c "$SCRIPT"
 
 sleep 3  # wait for server startup
 resp="$(mktemp)"
 trap 'rm $resp; docker stop $name' EXIT
 curl -fsSL -X POST \
     -H 'Content-Type: application/json' \
-    --data '{"context":{"procedure_source_url": "file:///src/python/tests/procedures/setuid", "replicate_api_token": "token"}, "input":{"s":"hello"}}' \
+    --data '{"context":{"procedure_source_url": "file:///procedures/setuid", "replicate_api_token": "token"}, "input":{"s":"hello"}}' \
     "http://localhost:$port/procedures" > "$resp"
 
 status="$(jq --raw-output '.status' < "$resp")"


### PR DESCRIPTION
Symlinks are not readable if the parent directory of src URL is not readable by the unprivileged user. So copy everything and chown after to avoid that.
