### PR TITLE
Support enums

### DIFF
--- a/python/coglet/adt.py
+++ b/python/coglet/adt.py
@@ -81,15 +81,21 @@ class PrimitiveType(Enum):
 
     def normalize(self, value: Any) -> Any:
         pt = PrimitiveType._python_type()[self]
+        tpe = type(value)
         if self is PrimitiveType.CUSTOM:
             # Custom type, leave as is
             return value
         elif self in {self.PATH, self.SECRET}:
             # String-ly types, only upcast
-            return value if type(value) is pt else pt(value)
+            return value if tpe is pt else pt(value)
         else:
+            if issubclass(tpe, Enum):
+                assert issubclass(tpe, pt), (
+                    f'enum {tpe.__name__} is used as {pt.__name__} but does not extend it'
+                )
+                value = value.value
             v = pt(value)
-            assert v == value, f'failed to normalize value {value} as {pt}'
+            assert v == value, f'failed to normalize value {value} as {pt.__name__}'
             return v
 
     def python_type(self) -> str:

--- a/python/coglet/adt.py
+++ b/python/coglet/adt.py
@@ -109,7 +109,7 @@ class PrimitiveType(Enum):
         if self is self.FLOAT:
             return float(value)
         elif self in {self.PATH, self.SECRET}:
-            # Leave these as is and let file runner handle special encoding
+            # Leave these as is and let the file runner handle special encoding
             return value
         else:
             return value
@@ -131,7 +131,7 @@ class FieldType:
     def from_type(tpe: type):
         if typing.get_origin(tpe) is list:
             t_args = typing.get_args(tpe)
-            assert len(t_args) == 1, 'list must have one type argument'
+            assert len(t_args) == 1, 'List must have one type argument'
             elem_t = t_args[0]
             # Fail fast to avoid the cryptic "unsupported Cog type" error later with elem_t
             nested_t = typing.get_origin(elem_t)

--- a/python/tests/bad_predictors/input_enum_choices.py
+++ b/python/tests/bad_predictors/input_enum_choices.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+from cog import BasePredictor, Input
+
+ERROR = 'enum Colors is used as str but does not extend it'
+
+
+class Colors(Enum):
+    RED = 'red'
+    GREEN = 'green'
+    BLUE = 'blue'
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        pass
+
+    def predict(self, c: str = Input(choices=list(Colors))) -> str:
+        pass

--- a/python/tests/bad_predictors/input_enum_default.py
+++ b/python/tests/bad_predictors/input_enum_default.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+from cog import BasePredictor, Input
+
+ERROR = 'enum Colors is used as str but does not extend it'
+
+
+class Colors(Enum):
+    RED = 'red'
+    GREEN = 'green'
+    BLUE = 'blue'
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        pass
+
+    def predict(self, c: str = Input(default=Colors.RED)) -> str:
+        pass

--- a/python/tests/schemas/enums.json
+++ b/python/tests/schemas/enums.json
@@ -1,0 +1,440 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Cog",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/shutdown": {
+      "post": {
+        "summary": "Start Shutdown",
+        "operationId": "start_shutdown_shutdown_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Start Shutdown Shutdown Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Root  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health-check": {
+      "get": {
+        "summary": "Healthcheck",
+        "operationId": "healthcheck_health_check_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Healthcheck Health Check Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions": {
+      "post": {
+        "summary": "Predict",
+        "description": "Run a single prediction on the model",
+        "operationId": "predict_predictions_post",
+        "parameters": [
+          {
+            "name": "prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Prefer",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}": {
+      "put": {
+        "summary": "Predict Idempotent",
+        "description": "Run a single prediction on the model (idempotent creation).",
+        "operationId": "predict_idempotent_predictions__prediction_id__put",
+        "parameters": [
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            }
+          },
+          {
+            "name": "prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Prefer",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PredictionRequest"
+                  }
+                ],
+                "title": "Prediction Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}/cancel": {
+      "post": {
+        "summary": "Cancel",
+        "description": "Cancel a running prediction",
+        "operationId": "cancel_predictions__prediction_id__cancel_post",
+        "parameters": [
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Cancel Predictions  Prediction Id  Cancel Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Input": {
+        "properties": {
+          "c": {
+            "default": "red",
+            "x-order": 0,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/c"
+              }
+            ]
+          },
+          "n": {
+            "type": "number",
+            "title": "N",
+            "default": 2.71828,
+            "x-order": 1
+          }
+        },
+        "type": "object",
+        "title": "Input"
+      },
+      "Output": {
+        "type": "string",
+        "title": "Output"
+      },
+      "PredictionRequest": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input",
+            "nullable": true
+          },
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "context": {
+            "title": "Context",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "nullable": true
+          },
+          "output_file_prefix": {
+            "title": "Output File Prefix",
+            "type": "string",
+            "nullable": true
+          },
+          "webhook": {
+            "title": "Webhook",
+            "type": "string",
+            "maxLength": 65536,
+            "minLength": 1,
+            "format": "uri",
+            "nullable": true
+          },
+          "webhook_events_filter": {
+            "default": [
+              "start",
+              "output",
+              "logs",
+              "completed"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/WebhookEvent"
+            },
+            "type": "array",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "PredictionRequest"
+      },
+      "PredictionResponse": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input",
+            "nullable": true
+          },
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "completed_at": {
+            "title": "Completed At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "logs": {
+            "type": "string",
+            "title": "Logs",
+            "default": ""
+          },
+          "error": {
+            "title": "Error",
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/Status",
+            "nullable": true
+          },
+          "metrics": {
+            "title": "Metrics",
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "PredictionResponse"
+      },
+      "Status": {
+        "type": "string",
+        "enum": [
+          "starting",
+          "processing",
+          "succeeded",
+          "canceled",
+          "failed"
+        ],
+        "title": "Status",
+        "description": "An enumeration."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WebhookEvent": {
+        "type": "string",
+        "enum": [
+          "start",
+          "output",
+          "logs",
+          "completed"
+        ],
+        "title": "WebhookEvent",
+        "description": "An enumeration."
+      },
+      "c": {
+        "type": "string",
+        "enum": [
+          "red",
+          "green",
+          "blue"
+        ],
+        "title": "c",
+        "description": "An enumeration."
+      }
+    }
+  }
+}

--- a/python/tests/schemas/enums.py
+++ b/python/tests/schemas/enums.py
@@ -1,0 +1,55 @@
+from enum import Enum
+
+from cog import BasePredictor, Input
+
+
+class Colors(str, Enum):
+    RED = 'red'
+    GREEN = 'green'
+    BLUE = 'blue'
+
+
+class Numbers(float, Enum):
+    E = 2.71828
+    PHI = 1.618
+    PI = 3.14
+
+
+FIXTURE = [
+    (
+        {},
+        'red:FF0000,2.71828:epsilon',
+    ),
+    (
+        {'c': Colors.GREEN, 'n': Numbers.PHI},
+        'green:00FF00,1.618:phi',
+    ),
+]
+
+
+class Predictor(BasePredictor):
+    setup_done = False
+
+    def setup(self) -> None:
+        self.setup_done = True
+
+    def predict(
+        self,
+        c: str = Input(default=Colors.RED, choices=[c.value for c in Colors]),
+        n: float = Input(default=Numbers.E),
+    ) -> str:
+        cs = ''
+        if c == Colors.RED:
+            cs = 'FF0000'
+        elif c == Colors.GREEN:
+            cs = '00FF00'
+        elif c == Colors.BLUE:
+            cs = '0000FF'
+        ns = ''
+        if n == Numbers.E:
+            ns = 'epsilon'
+        elif n == Numbers.PHI:
+            ns = 'phi'
+        elif n == Numbers.PI:
+            ns = 'pi'
+        return f'{c}:{cs},{n}:{ns}'


### PR DESCRIPTION
Allow enums in `default` & `choices` fields of `Input`.

* Enum must extend the same field type, e.g. `Class Colors(str, Enum)` for `c: str=Input(default=Colors.RED)`
* Extract the enum value e.g. `RED = "red"` as inputs