### PR TITLE
Make input files 0o666

### DIFF
--- a/internal/server/path.go
+++ b/internal/server/path.go
@@ -141,6 +141,7 @@ func base64ToInput(s string, paths *[]string) (string, error) {
 		return "", err
 	}
 	*paths = append(*paths, f.Name())
+	os.Chmod(f.Name(), 0o666)
 	return f.Name(), nil
 }
 
@@ -166,6 +167,7 @@ func urlToInput(s string, paths *[]string) (string, error) {
 		return "", err
 	}
 	*paths = append(*paths, f.Name())
+	os.Chmod(f.Name(), 0o666)
 	return f.Name(), nil
 }
 

--- a/python/tests/procedures/setuid/predict.py
+++ b/python/tests/procedures/setuid/predict.py
@@ -1,11 +1,13 @@
 import os
 import tempfile
 
+from cog import Path
+
 BASE_UID = 9000
 NOGROUP_GID = 65534
 
 
-def predict(s: str) -> str:
+def predict(p: Path) -> Path:
     uid = os.getuid()
     gid = os.getgid()
     print(f'UID={uid}')
@@ -13,9 +15,8 @@ def predict(s: str) -> str:
     assert uid >= BASE_UID
     assert gid == NOGROUP_GID
 
-    # CWD is a "copy" of the procedure source
-    # where directories are created with UID/GID
-    # while files are symlinked
+    # CWD is a copy of the procedure source
+    # where all directories and files are owned by UID/GID
     cwd = os.getcwd()
     print(f'CWD={cwd}')
     stat = os.stat(cwd)
@@ -38,4 +39,8 @@ def predict(s: str) -> str:
         print(f'writing to file: {f.name}')
         f.write('out')
 
-    return s
+    with p.open() as fin:
+        with open('out.txt', 'w') as fout:
+            fout.write(fin.read())
+
+    return Path('out.txt')

--- a/script/test-setuid.sh
+++ b/script/test-setuid.sh
@@ -36,7 +36,7 @@ resp="$(mktemp)"
 trap 'rm $resp; docker stop $name' EXIT
 curl -fsSL -X POST \
     -H 'Content-Type: application/json' \
-    --data '{"context":{"procedure_source_url": "file:///procedures/setuid", "replicate_api_token": "token"}, "input":{"s":"hello"}}' \
+    --data '{"context":{"procedure_source_url": "file:///procedures/setuid", "replicate_api_token": "token"}, "input":{"p":"https://raw.githubusercontent.com/replicate/cog-runtime/refs/heads/main/.python-version"}}' \
     "http://localhost:$port/procedures" > "$resp"
 
 status="$(jq --raw-output '.status' < "$resp")"


### PR DESCRIPTION
* By default temp files are created with 0o600
* Change them to 0o666 so that unprivileged runners can still read them
