### PR TITLE
Future-proof predictor inspection

### DIFF
--- a/python/coglet/inspector.py
+++ b/python/coglet/inspector.py
@@ -350,6 +350,19 @@ def create_predictor(
     module_name: str, predictor_name: str, inspect_ast: bool = False
 ) -> adt.Predictor:
     module = importlib.import_module(module_name)
+
+    # "from __future__ import annotations" turns all type annotations from actual types to strings
+    # and break all inspection logic
+    import __future__
+
+    if (
+        hasattr(module, 'annotations')
+        and getattr(module, 'annotations') == __future__.annotations
+    ):
+        raise AssertionError(
+            'predictor with "from __future__ import annotations" is not supported'
+        )
+
     fullname = f'{module_name}.{predictor_name}'
     assert hasattr(module, predictor_name), f'predictor not found: {fullname}'
     p = getattr(module, predictor_name)

--- a/python/tests/bad_predictors/future.py
+++ b/python/tests/bad_predictors/future.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from cog import BaseModel, BasePredictor
+
+ERROR = 'predictor with "from __future__ import annotations" is not supported'
+
+
+class BadOutput(BaseModel):
+    pass
+
+
+class Predictor(BasePredictor):
+    def setup(self) -> None:
+        pass
+
+    def predict(self, s: str) -> str:
+        return s


### PR DESCRIPTION
Detect and fail early on `from __future__ import annotations` which breaks all inspection.