### PR TITLE
No Runtime Panics/No `replicate/go/must`

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/replicate/go/must"
 )
 
 func main() {
@@ -16,10 +14,16 @@ func main() {
 		for k, v := range r.Header {
 			fmt.Printf("%s: %v\n", k, v)
 		}
-		body := string(must.Get(io.ReadAll(r.Body)))
-		if body != "" {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			fmt.Printf("failed to read body: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		bodyStr := string(body)
+		if bodyStr != "" {
 			fmt.Println("----- Body -----")
-			fmt.Println(body)
+			fmt.Println(bodyStr)
 		}
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/server/runner.go
+++ b/internal/server/runner.go
@@ -586,7 +586,15 @@ func (r *Runner) handleResponses() error {
 			pr.sendWebhook(WebhookOutput)
 		} else if pr.response.Status.IsCompleted() {
 			if pr.response.Status == PredictionSucceeded {
-				t := util.ParseTime(pr.response.CompletedAt).Sub(util.ParseTime(pr.response.StartedAt)).Seconds()
+				completedAt, err := util.ParseTime(pr.response.CompletedAt)
+				if err != nil {
+					return fmt.Errorf("failed to parse time: %w", err)
+				}
+				startedAt, err := util.ParseTime(pr.response.StartedAt)
+				if err != nil {
+					return fmt.Errorf("failed to parse time: %w", err)
+				}
+				t := completedAt.Sub(startedAt).Seconds()
 				if pr.response.Metrics == nil {
 					pr.response.Metrics = make(map[string]any)
 				}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -508,7 +508,11 @@ func (h *Handler) Predict(w http.ResponseWriter, r *http.Request) {
 		req.Id = id
 	}
 	if req.Id == "" {
-		req.Id = util.PredictionId()
+		req.Id, err = util.PredictionId()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	var c chan PredictionResponse

--- a/internal/tests/prediction_test.go
+++ b/internal/tests/prediction_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/replicate/go/must"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/server"
 )
@@ -87,8 +87,10 @@ func TestPredictionCrash(t *testing.T) {
 		resp := ct.PredictionReq(http.MethodPost, "/predictions", req)
 		// Compat: legacy Cog returns HTTP 500 and "Internal Server Error"
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		body := string(must.Get(io.ReadAll(resp.Body)))
-		assert.Equal(t, "Internal Server Error", body)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		bodyStr := string(body)
+		assert.Equal(t, "Internal Server Error", bodyStr)
 		// Compat: flaky server?
 		time.Sleep(100 * time.Millisecond)
 		assert.Equal(t, "DEFUNCT", ct.HealthCheck().Status)

--- a/internal/tests/setup_test.go
+++ b/internal/tests/setup_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/replicate/go/must"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/server"
 )
@@ -20,7 +20,9 @@ func TestSetupSucceeded(t *testing.T) {
 	assert.Equal(t, server.StatusReady.String(), hc.Status)
 	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
 	assert.Equal(t, "starting setup\nsetup in progress 1/1\ncompleted setup\n", hc.Setup.Logs)
-	assert.Equal(t, http.StatusOK, must.Get(http.DefaultClient.Get(ct.Url("/openapi.json"))).StatusCode)
+	resp, err := http.DefaultClient.Get(ct.Url("/openapi.json"))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	ct.Shutdown()
 	assert.NoError(t, ct.Cleanup())

--- a/internal/tests/shutdown_test.go
+++ b/internal/tests/shutdown_test.go
@@ -4,8 +4,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/replicate/go/must"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/server"
 )
@@ -22,7 +22,8 @@ func TestShutdownByServerSigInt(t *testing.T) {
 	assert.Equal(t, server.StatusReady.String(), hc.Status)
 	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
 
-	must.Do(syscall.Kill(ct.ServerPid(), syscall.SIGINT))
+	err := syscall.Kill(ct.ServerPid(), syscall.SIGINT)
+	require.NoError(t, err)
 	assert.NoError(t, ct.Cleanup())
 	assert.Equal(t, 0, ct.cmd.ProcessState.ExitCode())
 }
@@ -35,7 +36,8 @@ func TestShutdownByServerSigTerm(t *testing.T) {
 	assert.Equal(t, server.StatusReady.String(), hc.Status)
 	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
 
-	must.Do(syscall.Kill(ct.ServerPid(), syscall.SIGTERM))
+	err := syscall.Kill(ct.ServerPid(), syscall.SIGTERM)
+	require.NoError(t, err)
 	assert.NoError(t, ct.Cleanup())
 	assert.Equal(t, 0, ct.cmd.ProcessState.ExitCode())
 }
@@ -50,7 +52,8 @@ func TestShutdownIgnoreSignal(t *testing.T) {
 	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
 
 	// Ignore SIGTERM
-	must.Do(syscall.Kill(ct.ServerPid(), syscall.SIGTERM))
+	err := syscall.Kill(ct.ServerPid(), syscall.SIGTERM)
+	require.NoError(t, err)
 	assert.Nil(t, ct.cmd.ProcessState)
 	assert.Equal(t, server.StatusReady.String(), ct.HealthCheck().Status)
 
@@ -59,7 +62,8 @@ func TestShutdownIgnoreSignal(t *testing.T) {
 		ct.Shutdown()
 	} else {
 		// Handle SIGINT
-		must.Do(syscall.Kill(ct.ServerPid(), syscall.SIGINT))
+		err := syscall.Kill(ct.ServerPid(), syscall.SIGINT)
+		require.NoError(t, err)
 	}
 	assert.NoError(t, ct.Cleanup())
 	assert.Equal(t, 0, ct.cmd.ProcessState.ExitCode())
@@ -77,7 +81,8 @@ func TestShutdownProcedureIgnoreSignal(t *testing.T) {
 	assert.Equal(t, server.StatusReady.String(), hc.Status)
 	assert.Equal(t, server.SetupSucceeded, hc.Setup.Status)
 
-	must.Do(syscall.Kill(ct.ServerPid(), syscall.SIGTERM))
+	err := syscall.Kill(ct.ServerPid(), syscall.SIGTERM)
+	require.NoError(t, err)
 	assert.Nil(t, ct.cmd.ProcessState)
 	assert.Equal(t, server.StatusReady.String(), ct.HealthCheck().Status)
 

--- a/internal/util/find_port.go
+++ b/internal/util/find_port.go
@@ -3,8 +3,6 @@ package util
 import (
 	"net"
 	"sync"
-
-	"github.com/replicate/go/must"
 )
 
 var (
@@ -17,17 +15,23 @@ type PortFinder struct {
 	mu    sync.Mutex
 }
 
-func FindPort() int {
+func FindPort() (int, error) {
 	portsMu.Lock()
 	defer portsMu.Unlock()
 	for {
-		a := must.Get(net.ResolveTCPAddr("tcp", "localhost:0"))
-		l := must.Get(net.ListenTCP("tcp", a))
+		a, err := net.ResolveTCPAddr("tcp", "localhost:0")
+		if err != nil {
+			return 0, err
+		}
+		l, err := net.ListenTCP("tcp", a)
+		if err != nil {
+			return 0, err
+		}
 		p := l.Addr().(*net.TCPAddr).Port
 		if _, ok := ports[p]; !ok {
 			ports[p] = true
 			l.Close()
-			return p
+			return p, nil
 		}
 	}
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/replicate/go/httpclient"
 	"github.com/replicate/go/logging"
-	"github.com/replicate/go/must"
 	"github.com/replicate/go/uuid"
 	"gopkg.in/yaml.v3"
 )
@@ -59,14 +58,17 @@ func (y *CogYaml) PredictModuleAndPredictor() (string, string, error) {
 }
 
 // api.git: internal/logic/id.go
-func PredictionId() string {
-	u := must.Get(uuid.NewV7())
+func PredictionId() (string, error) {
+	u, err := uuid.NewV7()
+	if err != nil {
+		return "", err
+	}
 	shuffle := make([]byte, uuid.Size)
 	for i := 0; i < 4; i++ {
 		shuffle[i], shuffle[i+4], shuffle[i+8], shuffle[i+12] = u[i+12], u[i+4], u[i], u[i+8]
 	}
 	encoding := base32.NewEncoding("0123456789abcdefghjkmnpqrstvwxyz").WithPadding(base32.NoPadding)
-	return encoding.EncodeToString(shuffle)
+	return encoding.EncodeToString(shuffle), nil
 }
 
 const TimeLayout = "2006-01-02T15:04:05.999999-07:00"
@@ -80,8 +82,12 @@ func FormatTime(t time.Time) string {
 	return t.UTC().Format(TimeLayout)
 }
 
-func ParseTime(t string) time.Time {
-	return must.Get(time.Parse(TimeLayout, t))
+func ParseTime(t string) (time.Time, error) {
+	parsedTime, err := time.Parse(TimeLayout, t)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsedTime, nil
 }
 
 func JoinLogs(logs []string) string {


### PR DESCRIPTION
This change eliminates runtime panics in the runner and server. General code hygiene dictates that we should never crash for a recoverable error. This commit removes use of `replicate/go/must` in the runner and server.

Eliminated the use of must and associated panics across all runtime code paths, all go tests, and both `main.go` files.

Testing use of `must` while convenient encourages use of `panic` instead of actual validation.

Idiomatic go does not panic under normal circumstances.