### PR TITLE
Improve inspection of procedure mode

### DIFF
--- a/python/tests/bad_predictors/procedure_input_default_none_primitive.py
+++ b/python/tests/bad_predictors/procedure_input_default_none_primitive.py
@@ -1,0 +1,10 @@
+from cog import Input
+from tests.util import check_python_version
+
+check_python_version(min_version=(3, 10))
+
+ERROR = 'error-prone usage of default=None'
+
+
+def run(x: str = Input(default=None)) -> str:
+    pass

--- a/python/tests/bad_predictors/procedure_predict_fn.py
+++ b/python/tests/bad_predictors/procedure_predict_fn.py
@@ -1,0 +1,4 @@
+ERROR = 'invalid predictor tests.bad_predictors.procedure_predict_fn.run'
+
+
+run = 0

--- a/python/tests/bad_predictors/procedure_predict_kwarg.py
+++ b/python/tests/bad_predictors/procedure_predict_kwarg.py
@@ -1,0 +1,5 @@
+ERROR = 'run() must not have **kwargs'
+
+
+def run(**kwargs) -> None:
+    pass

--- a/python/tests/bad_predictors/procedure_predict_none.py
+++ b/python/tests/bad_predictors/procedure_predict_none.py
@@ -1,0 +1,5 @@
+ERROR = 'run() must not return None'
+
+
+def run(s: str) -> None:
+    pass

--- a/python/tests/bad_predictors/procedure_predict_vararg.py
+++ b/python/tests/bad_predictors/procedure_predict_vararg.py
@@ -1,0 +1,5 @@
+ERROR = 'run() must not have *args'
+
+
+def run(*args) -> None:
+    pass

--- a/python/tests/test_bad_predictor.py
+++ b/python/tests/test_bad_predictor.py
@@ -28,4 +28,7 @@ def run(module_name: str, predictor_name: str) -> None:
 @pytest.mark.parametrize('predictor', get_predictors())
 def test_bad_predictor(predictor):
     module_name = f'tests.bad_predictors.{predictor}'
-    run(module_name, 'Predictor')
+    if predictor.startswith('procedure_'):
+        run(module_name, 'run')
+    else:
+        run(module_name, 'Predictor')


### PR DESCRIPTION
* Handle `def run()` without `BasePredictor` in AST inspection
* Use actual function name instead of hard coded `predict` in error messages
