### PR TITLE
Flip inspect_ast conditions

### DIFF
--- a/python/coglet/file_runner.py
+++ b/python/coglet/file_runner.py
@@ -72,8 +72,9 @@ class FileRunner:
         self.logger.info('setup started')
         setup_result: Dict[str, Any] = {'started_at': util.now_iso()}
         try:
+            # Skip AST inspection for older models built before it was created
             p = inspector.create_predictor(
-                self.config.module_name, self.config.predictor_name
+                self.config.module_name, self.config.predictor_name, inspect_ast=False
             )
             with open(openapi_file, 'w') as f:
                 schema = schemas.to_json_schema(p)

--- a/python/coglet/inspector.py
+++ b/python/coglet/inspector.py
@@ -351,7 +351,7 @@ def _find_coders(module: ModuleType) -> None:
 
 
 def create_predictor(
-    module_name: str, predictor_name: str, inspect_ast: bool = False
+    module_name: str, predictor_name: str, inspect_ast: bool = True
 ) -> adt.Predictor:
     module = importlib.import_module(module_name)
 

--- a/python/coglet/schema.py
+++ b/python/coglet/schema.py
@@ -28,7 +28,7 @@ def main():
         # - Bad dependencies
         # - Bad input/output types
         # - Libraries downloading weights on init
-        p = inspector.create_predictor(sys.argv[1], sys.argv[2], inspect_ast=True)
+        p = inspector.create_predictor(sys.argv[1], sys.argv[2])
 
         # Skipping these for now as old models have no test inputs and will fail schema validation
         # Check that test_inputs exists and is valid

--- a/python/tests/cases/repetition.py
+++ b/python/tests/cases/repetition.py
@@ -16,7 +16,7 @@ class Output(BaseModel):
     od2: Optional[str]
     # List[T] not allowed for outputs, CSV instead
     ld0: str
-    ld1: str
+    # ld1: str
     ld2: str
 
 
@@ -28,7 +28,7 @@ FIXTURE = [
             'rd0': 'foo1',
             # 'rd1': 'foo2',  # Invalid default=None
             'ld0': ['bar1', 'baz1'],
-            'ld1': ['bar2', 'baz2'],
+            # 'ld1': ['bar2', 'baz2'],  # Invalid default=None
         },
         Output(
             rs='foo0',
@@ -41,7 +41,7 @@ FIXTURE = [
             od1=None,
             od2='bar',
             ld0='bar1,baz1',
-            ld1='bar2,baz2',
+            # ld1='bar2,baz2',  # Invalid default=None
             ld2='',
         ),
     ),
@@ -57,7 +57,7 @@ FIXTURE = [
             'od1': 'foo5',
             'od2': 'foo6',
             'ld0': ['bar1', 'baz1'],
-            'ld1': ['bar2', 'baz2'],
+            # 'ld1': ['bar2', 'baz2'],  # Invalid default=None
             'ld2': ['bar3', 'baz3'],
         },
         Output(
@@ -71,7 +71,7 @@ FIXTURE = [
             od1='foo5',
             od2='foo6',
             ld0='bar1,baz1',
-            ld1='bar2,baz2',
+            # ld1='bar2,baz2',  # Invalid default=None
             ld2='bar3,baz3',
         ),
     ),
@@ -99,7 +99,7 @@ class Predictor(BasePredictor):
         od1: Optional[str] = Input(default=None),
         od2: Optional[str] = Input(default='bar'),
         ld0: List[str] = Input(),
-        ld1: List[str] = Input(default=None),
+        # ld1: List[str] = Input(default=None),  # Invalid default=None
         ld2: List[str] = Input(default=[]),
     ) -> Output:
         return Output(
@@ -113,6 +113,6 @@ class Predictor(BasePredictor):
             od1=od1,
             od2=od2,
             ld0=','.join(ld0),
-            ld1=','.join(ld1),
+            # ld1=','.join(ld1),  # Invalid default=None
             ld2=','.join(ld2),
         )

--- a/python/tests/test_bad_predictor.py
+++ b/python/tests/test_bad_predictor.py
@@ -20,7 +20,7 @@ def run(module_name: str, predictor_name: str) -> None:
         m = importlib.import_module(module_name)
         err_msg = getattr(m, 'ERROR')
         with pytest.raises(AssertionError, match=re.escape(err_msg)):
-            inspector.create_predictor(module_name, predictor_name, inspect_ast=True)
+            inspector.create_predictor(module_name, predictor_name)
     except PythonVersionError as e:
         pytest.skip(reason=str(e))
 

--- a/python/tests/test_cases.py
+++ b/python/tests/test_cases.py
@@ -26,7 +26,7 @@ def test_repetition_schema():
 
     # Fields with default=None or missing default are required
     # Unless if type hint is `Optional[T]`
-    assert set(schema_in['required']) == {'rs', 'ls', 'rd0', 'ld0', 'ld1'}
+    assert set(schema_in['required']) == {'rs', 'ls', 'rd0', 'ld0'}
     for name, prop in schema_in['properties'].items():
         # x: Optional[T] implies nullable, regardless of default
         if name in {'os', 'od0', 'od1', 'od2'}:


### PR DESCRIPTION
So that we only turn it off when starting a model but keep it on for cog.command.openapi_schema and all tests.
