### PR TITLE
feat: Implement ForceKill

### DIFF
--- a/cmd/cog/main.go
+++ b/cmd/cog/main.go
@@ -27,7 +27,7 @@ type ServerConfig struct {
 	AwaitExplicitShutdown     bool          `ff:"long: await-explicit-shutdown, default: false, usage: await explicit shutdown"`
 	UploadURL                 string        `ff:"long: upload-url, nodefault, usage: output file upload URL"`
 	WorkingDirectory          string        `ff:"long: working-directory, nodefault, usage: explicit working directory override"`
-	RunnerShutdownGracePeriod time.Duration `ff:"long: runner-shutdown-grace-period, default: 5s, usage: how long to wait before force-killing runners after Stop()"`
+	RunnerShutdownGracePeriod time.Duration `ff:"long: runner-shutdown-grace-period, default: 600s, usage: how long to wait before force-killing runners after Stop()"`
 }
 
 var logger = util.CreateLogger("cog")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -232,6 +232,15 @@ func (h *Handler) Shutdown(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ForceKillAll immediately force-kills all runners (for test cleanup)
+func (h *Handler) ForceKillAll() {
+	for _, runner := range h.runners {
+		if runner != nil {
+			runner.ForceKill()
+		}
+	}
+}
+
 func (h *Handler) Stop() error {
 	log := logger.Sugar()
 	// Procedure mode and no runner yet
@@ -557,7 +566,7 @@ func (h *Handler) Predict(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "empty procedure_source_url or replicate_api_token", http.StatusBadRequest)
 			return
 		}
-		c, err = h.predictWithRunner(procedureSourceURL, req)
+		c, err = h.predictWithRunner(procedureSourceURL, req) //nolint:contextcheck // context passing not viable in current architecture
 	} else {
 		c, err = h.runners[DefaultRunnerID].Predict(req)
 	}

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -1,5 +1,7 @@
 package server
 
+import "time"
+
 type Status int
 
 const (
@@ -50,6 +52,10 @@ type Config struct {
 	// implementations may support alternate venvs or alternate python versions per
 	// runner.
 	PythonBinPath string
+
+	// RunnerShutdownGracePeriod configures how long to wait before force-killing
+	// runners after Stop() is called. Set to 0 to disable grace period.
+	RunnerShutdownGracePeriod time.Duration
 }
 
 type PredictConfig struct {


### PR DESCRIPTION
This commit implements a forcekill mechanism for the runner. This ensures that we are no longer leaking resources once the runner is shutdown.

Implementation details:
- `runner.ForceKill()` implemented
- process groups are now in place for all uses of exec.CommandContext
  - uses `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}`
- Migrated to exec.CommandContext to give a proper lifecycle to the CMD
- LegacyCog smoke test also has an explicit ForceKill functionality
- Comprehensive Unit test for ForceKill has been added
- Test Harness leaverages a graceperiod of 0 to kill runners immediately
- Main cli can pass a fixed graceperiod for runners, with a default value