### PR TITLE
Eliminate runtime panics

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -11,7 +11,11 @@ base_dir="$(git rev-parse --show-toplevel)"
 cd "$base_dir"
 
 test_go() {
-    go run gotest.tools/gotestsum@latest --format testname ./... -- -timeout=30s "$@"
+    format="dots-v2"
+    if [ -n "${GITHUB_ACTIONS:-}" ]; then
+        format="github-actions"
+    fi
+    go run gotest.tools/gotestsum@latest --format "$format" ./... -- -timeout=30s "$@"
 }
 
 test_python() {


### PR DESCRIPTION
Eliminate the last runtime panics that could take down the whole server. These are replaced with context-based management. This is overly complex due to the lack of a server-wide context (and derived runner contexts). Future changes will remediate the context sprawl.