### PR TITLE
Implement type checker compatible Input() function

### DIFF
--- a/internal/tests/input_function_test.go
+++ b/internal/tests/input_function_test.go
@@ -1,0 +1,292 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog-runtime/internal/server"
+)
+
+func TestInputFunctionSchemaGeneration(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("Input generation tests coglet specific implementations.")
+	}
+	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
+		procedureMode:    false,
+		explicitShutdown: false,
+		uploadURL:        "",
+		module:           "input_function",
+		predictorClass:   "Predictor",
+	})
+
+	waitForSetupComplete(t, runtimeServer, server.StatusReady, server.SetupSucceeded)
+
+	resp, err := http.Get(runtimeServer.URL + "/openapi.json")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var schema map[string]any
+	err = json.Unmarshal(body, &schema)
+	require.NoError(t, err)
+
+	assert.Contains(t, schema, "components")
+
+	components := schema["components"].(map[string]any)
+	assert.Contains(t, components, "schemas")
+
+	schemas := components["schemas"].(map[string]any)
+	assert.Contains(t, schemas, "Input")
+
+	inputSchema := schemas["Input"].(map[string]any)
+	assert.Equal(t, "object", inputSchema["type"])
+	assert.Contains(t, inputSchema, "properties")
+	assert.Contains(t, inputSchema, "required")
+
+	properties := inputSchema["properties"].(map[string]any)
+	required := inputSchema["required"].([]any)
+
+	assert.Contains(t, properties, "message")
+	assert.Contains(t, required, "message")
+	messageField := properties["message"].(map[string]any)
+	assert.Equal(t, "string", messageField["type"])
+	assert.Equal(t, "Message to process", messageField["description"])
+
+	assert.Contains(t, properties, "repeat_count")
+	assert.NotContains(t, required, "repeat_count")
+	repeatField := properties["repeat_count"].(map[string]any)
+	assert.Equal(t, "integer", repeatField["type"])
+	assert.Equal(t, float64(1), repeatField["default"])  //nolint:testifylint // Checking absolute value not delta
+	assert.Equal(t, float64(1), repeatField["minimum"])  //nolint:testifylint // Checking absolute value not delta
+	assert.Equal(t, float64(10), repeatField["maximum"]) //nolint:testifylint // Checking absolute value not delta
+
+	assert.Contains(t, properties, "prefix")
+	prefixField := properties["prefix"].(map[string]any)
+	assert.Equal(t, "string", prefixField["type"])
+	assert.Equal(t, "Result: ", prefixField["default"])
+	assert.Equal(t, float64(1), prefixField["minLength"])  //nolint:testifylint // Checking absolute value not delta
+	assert.Equal(t, float64(20), prefixField["maxLength"]) //nolint:testifylint // Checking absolute value not delta
+
+	assert.Contains(t, properties, "deprecated_option")
+	deprecatedField := properties["deprecated_option"].(map[string]any)
+	assert.Equal(t, true, deprecatedField["deprecated"])
+}
+
+func TestInputFunctionBasicPrediction(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("Input generation tests coglet specific implementations.")
+	}
+	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
+		procedureMode:    false,
+		explicitShutdown: false,
+		uploadURL:        "",
+		module:           "input_function",
+		predictorClass:   "Predictor",
+	})
+
+	waitForSetupComplete(t, runtimeServer, server.StatusReady, server.SetupSucceeded)
+
+	input := map[string]any{"message": "hello world"}
+	req := httpPredictionRequest(t, runtimeServer, server.PredictionRequest{Input: input})
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var prediction server.PredictionResponse
+	err = json.Unmarshal(body, &prediction)
+	require.NoError(t, err)
+
+	assert.Equal(t, server.PredictionSucceeded, prediction.Status)
+	assert.Equal(t, "Result: hello world", prediction.Output)
+}
+
+func TestInputFunctionComplexPrediction(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("Input generation tests coglet specific implementations.")
+	}
+	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
+		procedureMode:    false,
+		explicitShutdown: false,
+		uploadURL:        "",
+		module:           "input_function",
+		predictorClass:   "Predictor",
+	})
+
+	waitForSetupComplete(t, runtimeServer, server.StatusReady, server.SetupSucceeded)
+
+	input := map[string]any{
+		"message":           "test message",
+		"repeat_count":      2,
+		"format_type":       "uppercase",
+		"prefix":            "Output: ",
+		"suffix":            " [END]",
+		"deprecated_option": "custom",
+	}
+	req := httpPredictionRequest(t, runtimeServer, server.PredictionRequest{Input: input})
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var prediction server.PredictionResponse
+	err = json.Unmarshal(body, &prediction)
+	require.NoError(t, err)
+
+	assert.Equal(t, server.PredictionSucceeded, prediction.Status)
+	assert.Equal(t, "Output: TEST MESSAGE TEST MESSAGE [END]", prediction.Output)
+}
+
+func TestInputFunctionConstraintViolations(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("Input generation tests coglet specific implementations.")
+	}
+	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
+		procedureMode:    false,
+		explicitShutdown: false,
+		uploadURL:        "",
+		module:           "input_function",
+		predictorClass:   "Predictor",
+	})
+
+	waitForSetupComplete(t, runtimeServer, server.StatusReady, server.SetupSucceeded)
+
+	testCases := []struct {
+		name     string
+		input    map[string]any
+		errorMsg string
+	}{
+		{
+			name:     "repeat_count too low",
+			input:    map[string]any{"message": "test", "repeat_count": 0},
+			errorMsg: "fails constraint >= 1",
+		},
+		{
+			name:     "repeat_count too high",
+			input:    map[string]any{"message": "test", "repeat_count": 11},
+			errorMsg: "fails constraint <= 10",
+		},
+		{
+			name:     "invalid format_type choice",
+			input:    map[string]any{"message": "test", "format_type": "invalid"},
+			errorMsg: "does not match choices",
+		},
+		{
+			name:     "prefix too short",
+			input:    map[string]any{"message": "test", "prefix": ""},
+			errorMsg: "fails constraint len() >= 1",
+		},
+		{
+			name:     "prefix too long",
+			input:    map[string]any{"message": "test", "prefix": strings.Repeat("x", 21)},
+			errorMsg: "fails constraint len() <= 20",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httpPredictionRequest(t, runtimeServer, server.PredictionRequest{Input: tc.input})
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			var errorResp server.PredictionResponse
+			err = json.Unmarshal(body, &errorResp)
+			require.NoError(t, err)
+
+			assert.Equal(t, server.PredictionFailed, errorResp.Status)
+			assert.Contains(t, errorResp.Error, tc.errorMsg)
+		})
+	}
+}
+
+func TestInputFunctionMissingRequired(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("Input generation tests coglet specific implementations.")
+	}
+	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
+		procedureMode:    false,
+		explicitShutdown: false,
+		uploadURL:        "",
+		module:           "input_function",
+		predictorClass:   "Predictor",
+	})
+
+	waitForSetupComplete(t, runtimeServer, server.StatusReady, server.SetupSucceeded)
+
+	input := map[string]any{"repeat_count": 2}
+	req := httpPredictionRequest(t, runtimeServer, server.PredictionRequest{Input: input})
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var errorResp server.PredictionResponse
+	err = json.Unmarshal(body, &errorResp)
+	require.NoError(t, err)
+
+	assert.Equal(t, server.PredictionFailed, errorResp.Status)
+	assert.Contains(t, errorResp.Error, "missing required input field: message")
+}
+
+func TestInputFunctionSimple(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("Input generation tests coglet specific implementations.")
+	}
+	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
+		procedureMode:    false,
+		explicitShutdown: false,
+		uploadURL:        "",
+		module:           "input_simple",
+		predictorClass:   "Predictor",
+	})
+
+	waitForSetupComplete(t, runtimeServer, server.StatusReady, server.SetupSucceeded)
+
+	input := map[string]any{"message": "hello", "count": 3}
+	req := httpPredictionRequest(t, runtimeServer, server.PredictionRequest{Input: input})
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var prediction server.PredictionResponse
+	err = json.Unmarshal(body, &prediction)
+	require.NoError(t, err)
+
+	assert.Equal(t, server.PredictionSucceeded, prediction.Status)
+	assert.Equal(t, "hellohellohello", prediction.Output)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
 ]
-dependencies = []
+dependencies = ["typing_extensions>=4.15"]
 
 [project.optional-dependencies]
 dev = [

--- a/python/coglet/inspector.py
+++ b/python/coglet/inspector.py
@@ -51,7 +51,7 @@ def _validate_predict(f: Callable, f_name: str, is_class_fn: bool) -> None:
     )
 
 
-def _validate_input(name: str, ft: adt.FieldType, cog_in: api.Input) -> None:
+def _validate_input(name: str, ft: adt.FieldType, cog_in: api.FieldInfo) -> None:
     cog_t = ft.primitive
     in_repr = f'{name}: {ft.python_type()}'
     defaults = []
@@ -122,7 +122,7 @@ def _validate_input(name: str, ft: adt.FieldType, cog_in: api.Input) -> None:
 
 
 def _input_adt(
-    order: int, name: str, tpe: type, cog_in: Optional[api.Input]
+    order: int, name: str, tpe: type, cog_in: Optional[api.FieldInfo]
 ) -> adt.Input:
     try:
         ft = adt.FieldType.from_type(tpe)

--- a/python/tests/runners/input_function.py
+++ b/python/tests/runners/input_function.py
@@ -1,0 +1,69 @@
+"""Test predictor specifically for testing the Input() function changes in Go test hardness."""
+
+from typing import Optional
+
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    """Test predictor demonstrating Input() function usage."""
+
+    test_inputs = {
+        'message': 'hello world',
+        'repeat_count': 2,
+        'format_type': 'uppercase',
+        'prefix': 'Test: ',
+    }
+
+    def predict(
+        self,
+        # Basic required field
+        message: str = Input(description='Message to process'),
+        # Field with default
+        repeat_count: int = Input(
+            default=1, description='Number of times to repeat message', ge=1, le=10
+        ),
+        # Field with choices
+        format_type: str = Input(
+            default='plain',
+            description='Output format',
+            choices=['plain', 'uppercase', 'title'],
+        ),
+        # String constraints
+        prefix: str = Input(
+            default='Result: ',
+            description='Prefix for output',
+            min_length=1,
+            max_length=20,
+        ),
+        # Optional field
+        suffix: Optional[str] = Input(
+            default=None, description='Optional suffix for output'
+        ),
+        # Deprecated field
+        deprecated_option: str = Input(
+            default='deprecated_value',
+            description='This field is deprecated',
+            deprecated=True,
+        ),
+    ) -> str:
+        """Process the message according to the input parameters."""
+
+        # Apply formatting
+        if format_type == 'uppercase':
+            processed_message = message.upper()
+        elif format_type == 'title':
+            processed_message = message.title()
+        else:
+            processed_message = message
+
+        # Repeat the message
+        repeated = (processed_message + ' ') * repeat_count
+        repeated = repeated.rstrip()
+
+        # Add prefix and suffix
+        result = prefix + repeated
+        if suffix:
+            result += suffix
+
+        return result

--- a/python/tests/runners/input_simple.py
+++ b/python/tests/runners/input_simple.py
@@ -1,0 +1,20 @@
+"""Simple test runner for Input() function validation."""
+
+from cog import BasePredictor, Input
+
+
+class Predictor(BasePredictor):
+    """Simple test predictor for validating Input() function works correctly."""
+
+    test_inputs = {
+        'message': 'test',
+        'count': 3,
+    }
+
+    def predict(
+        self,
+        message: str = Input(description='Test message'),
+        count: int = Input(default=1, description='Repeat count', ge=1, le=5),
+    ) -> str:
+        """Simple predictor that repeats a message."""
+        return message * count

--- a/python/tests/schemas/input_function_test.json
+++ b/python/tests/schemas/input_function_test.json
@@ -1,0 +1,477 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Cog",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/shutdown": {
+      "post": {
+        "summary": "Start Shutdown",
+        "operationId": "start_shutdown_shutdown_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Start Shutdown Shutdown Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Root  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health-check": {
+      "get": {
+        "summary": "Healthcheck",
+        "operationId": "healthcheck_health_check_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Healthcheck Health Check Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions": {
+      "post": {
+        "summary": "Predict",
+        "description": "Run a single prediction on the model",
+        "operationId": "predict_predictions_post",
+        "parameters": [
+          {
+            "name": "prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Prefer",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}": {
+      "put": {
+        "summary": "Predict Idempotent",
+        "description": "Run a single prediction on the model (idempotent creation).",
+        "operationId": "predict_idempotent_predictions__prediction_id__put",
+        "parameters": [
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            }
+          },
+          {
+            "name": "prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "title": "Prefer",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PredictionRequest"
+                  }
+                ],
+                "title": "Prediction Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predictions/{prediction_id}/cancel": {
+      "post": {
+        "summary": "Cancel",
+        "description": "Cancel a running prediction",
+        "operationId": "cancel_predictions__prediction_id__cancel_post",
+        "parameters": [
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction ID"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Cancel Predictions  Prediction Id  Cancel Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "PredictionRequest": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input",
+            "nullable": true
+          },
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "nullable": true
+          },
+          "context": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true,
+            "title": "Context",
+            "type": "object"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "output_file_prefix": {
+            "title": "Output File Prefix",
+            "type": "string",
+            "nullable": true
+          },
+          "webhook": {
+            "title": "Webhook",
+            "type": "string",
+            "maxLength": 65536,
+            "minLength": 1,
+            "format": "uri",
+            "nullable": true
+          },
+          "webhook_events_filter": {
+            "default": [
+              "start",
+              "output",
+              "logs",
+              "completed"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/WebhookEvent"
+            },
+            "type": "array",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "PredictionRequest"
+      },
+      "PredictionResponse": {
+        "properties": {
+          "input": {
+            "$ref": "#/components/schemas/Input",
+            "nullable": true
+          },
+          "output": {
+            "$ref": "#/components/schemas/Output"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "completed_at": {
+            "title": "Completed At",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "logs": {
+            "type": "string",
+            "title": "Logs",
+            "default": ""
+          },
+          "error": {
+            "title": "Error",
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/Status",
+            "nullable": true
+          },
+          "metrics": {
+            "title": "Metrics",
+            "type": "object",
+            "additionalProperties": true,
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "PredictionResponse"
+      },
+      "Status": {
+        "type": "string",
+        "enum": [
+          "starting",
+          "processing",
+          "succeeded",
+          "canceled",
+          "failed"
+        ],
+        "title": "Status",
+        "description": "An enumeration."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WebhookEvent": {
+        "type": "string",
+        "enum": [
+          "start",
+          "output",
+          "logs",
+          "completed"
+        ],
+        "title": "WebhookEvent",
+        "description": "An enumeration."
+      },
+      "Input": {
+        "properties": {
+          "message": {
+            "x-order": 0,
+            "title": "Message",
+            "type": "string",
+            "description": "Message to process"
+          },
+          "repeat_count": {
+            "x-order": 1,
+            "title": "Repeat Count",
+            "type": "integer",
+            "default": 1,
+            "description": "Number of times to repeat message",
+            "minimum": 1.0,
+            "maximum": 10.0
+          },
+          "format_type": {
+            "x-order": 2,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/format_type"
+              }
+            ],
+            "default": "plain",
+            "description": "Output format"
+          },
+          "prefix": {
+            "x-order": 3,
+            "title": "Prefix",
+            "type": "string",
+            "default": "Result: ",
+            "description": "Prefix for output",
+            "minLength": 1,
+            "maxLength": 20
+          },
+          "suffix": {
+            "x-order": 4,
+            "title": "Suffix",
+            "type": "string",
+            "description": "Optional suffix for output"
+          },
+          "legacy_option": {
+            "x-order": 5,
+            "title": "Legacy Option",
+            "type": "string",
+            "default": "deprecated_value",
+            "description": "This field is deprecated",
+            "deprecated": true
+          }
+        },
+        "type": "object",
+        "title": "Input",
+        "required": [
+          "message",
+          "suffix"
+        ]
+      },
+      "Output": {
+        "title": "Output",
+        "type": "string"
+      },
+      "format_type": {
+        "title": "format_type",
+        "description": "An enumeration.",
+        "enum": [
+          "plain",
+          "uppercase",
+          "title"
+        ],
+        "type": "string"
+      }
+    }
+  }
+}

--- a/python/tests/test_input_function.py
+++ b/python/tests/test_input_function.py
@@ -1,0 +1,220 @@
+"""Unit tests for the Input() function and InputSpec dataclass."""
+
+import pytest
+
+from coglet.api import FieldInfo, Input
+
+
+class TestInputSpec:
+    """Test the InputSpec dataclass."""
+
+    def test_default_values(self):
+        """Test InputSpec with all default values."""
+        spec = FieldInfo()
+        assert spec.default is None
+        assert spec.description is None
+        assert spec.ge is None
+        assert spec.le is None
+        assert spec.min_length is None
+        assert spec.max_length is None
+        assert spec.regex is None
+        assert spec.choices is None
+        assert spec.deprecated is None
+
+    def test_custom_values(self):
+        """Test InputSpec with custom values."""
+        spec = FieldInfo(
+            default='test',
+            description='A test field',
+            ge=1,
+            le=10,
+            min_length=2,
+            max_length=20,
+            regex=r'\d+',
+            choices=['a', 'b', 'c'],
+            deprecated=True,
+        )
+        assert spec.default == 'test'
+        assert spec.description == 'A test field'
+        assert spec.ge == 1
+        assert spec.le == 10
+        assert spec.min_length == 2
+        assert spec.max_length == 20
+        assert spec.regex == r'\d+'
+        assert spec.choices == ['a', 'b', 'c']
+        assert spec.deprecated is True
+
+    def test_frozen_dataclass(self):
+        """Test that InputSpec is frozen (immutable)."""
+        spec = FieldInfo(default='test')
+        with pytest.raises(AttributeError):
+            spec.default = 'changed'
+
+
+class TestInputFunction:
+    """Test the Input() function."""
+
+    def test_input_no_args(self):
+        """Test Input() with no arguments."""
+        result = Input()
+        assert isinstance(result, FieldInfo)
+        assert result.default is None
+        assert result.description is None
+
+    def test_input_default_only(self):
+        """Test Input() with default value only."""
+        result = Input('test_default')
+        assert isinstance(result, FieldInfo)
+        assert result.default == 'test_default'
+        assert result.description is None
+
+    def test_input_all_params(self):
+        """Test Input() with all parameters."""
+        result = Input(
+            default=42,
+            description='Test field',
+            ge=0,
+            le=100,
+            min_length=1,
+            max_length=50,
+            regex=r'^\d+$',
+            choices=[1, 2, 3],
+            deprecated=False,
+        )
+        assert isinstance(result, FieldInfo)
+        assert result.default == 42
+        assert result.description == 'Test field'
+        assert result.ge == 0
+        assert result.le == 100
+        assert result.min_length == 1
+        assert result.max_length == 50
+        assert result.regex == r'^\d+$'
+        assert result.choices == [1, 2, 3]
+        assert result.deprecated is False
+
+    def test_input_keyword_only(self):
+        """Test that non-default parameters are keyword-only."""
+        # This should work
+        result = Input(default='test', description='desc')
+        assert result.default == 'test'
+        assert result.description == 'desc'
+
+        # This would be a syntax error if description wasn't keyword-only
+        # Input("test", "desc")  # Would fail if not keyword-only
+
+    def test_input_return_type_is_any(self):
+        """Test that Input() has return type Any for type checkers."""
+        # This is more of a static analysis test, but we can verify
+        # that the function returns InputSpec at runtime
+        result = Input(description='test')
+        assert isinstance(result, FieldInfo)
+
+
+class TestInputUsagePatterns:
+    """Test common usage patterns of Input()."""
+
+    def test_basic_field(self):
+        """Test basic field definition pattern."""
+        # Simulate: name: str = Input()
+        field_spec = Input()
+        assert isinstance(field_spec, FieldInfo)
+        assert field_spec.default is None
+
+    def test_field_with_default(self):
+        """Test field with default value."""
+        # Simulate: name: str = Input(default="foo")
+        field_spec = Input(default='foo')
+        assert field_spec.default == 'foo'
+
+    def test_field_with_description(self):
+        """Test field with description."""
+        # Simulate: name: str = Input(description="User's name")
+        field_spec = Input(description="User's name")
+        assert field_spec.description == "User's name"
+
+    def test_numeric_constraints(self):
+        """Test numeric constraint fields."""
+        # Simulate: age: int = Input(ge=0, le=120)
+        field_spec = Input(ge=0, le=120)
+        assert field_spec.ge == 0
+        assert field_spec.le == 120
+
+    def test_string_constraints(self):
+        """Test string constraint fields."""
+        # Simulate: name: str = Input(min_length=1, max_length=50)
+        field_spec = Input(min_length=1, max_length=50)
+        assert field_spec.min_length == 1
+        assert field_spec.max_length == 50
+
+    def test_regex_constraint(self):
+        """Test regex constraint field."""
+        # Simulate: email: str = Input(regex=r'.*@.*')
+        field_spec = Input(regex=r'.*@.*')
+        assert field_spec.regex == r'.*@.*'
+
+    def test_choices_constraint(self):
+        """Test choices constraint field."""
+        # Simulate: color: str = Input(choices=['red', 'green', 'blue'])
+        field_spec = Input(choices=['red', 'green', 'blue'])
+        assert field_spec.choices == ['red', 'green', 'blue']
+
+    def test_deprecated_field(self):
+        """Test deprecated field."""
+        # Simulate: old_param: str = Input(deprecated=True)
+        field_spec = Input(deprecated=True)
+        assert field_spec.deprecated is True
+
+    def test_complex_field(self):
+        """Test field with multiple constraints."""
+        # Simulate: score: int = Input(
+        #     default=50,
+        #     description="Score between 0 and 100",
+        #     ge=0,
+        #     le=100
+        # )
+        field_spec = Input(
+            default=50, description='Score between 0 and 100', ge=0, le=100
+        )
+        assert field_spec.default == 50
+        assert field_spec.description == 'Score between 0 and 100'
+        assert field_spec.ge == 0
+        assert field_spec.le == 100
+
+
+class TestTypeCompatibility:
+    """Test that Input() works with type annotations."""
+
+    def test_string_annotation(self):
+        """Test Input() used with string type annotation."""
+        # This simulates: name: str = Input()
+        # The type checker should see this as valid
+        field_spec = Input()
+        assert isinstance(field_spec, FieldInfo)
+
+    def test_optional_annotation(self):
+        """Test Input() used with Optional type annotation."""
+        # This simulates: name: Optional[str] = Input()
+        field_spec = Input()
+        assert isinstance(field_spec, FieldInfo)
+
+    def test_list_annotation(self):
+        """Test Input() used with List type annotation."""
+        # This simulates: names: List[str] = Input()
+        field_spec = Input()
+        assert isinstance(field_spec, FieldInfo)
+
+    def test_with_defaults_various_types(self):
+        """Test Input() with defaults of various types."""
+        str_field = Input(default='string')
+        int_field = Input(default=42)
+        float_field = Input(default=3.14)
+        bool_field = Input(default=True)
+        list_field = Input(default=[1, 2, 3])
+        none_field = Input(default=None)
+
+        assert str_field.default == 'string'
+        assert int_field.default == 42
+        assert float_field.default == 3.14
+        assert bool_field.default is True
+        assert list_field.default == [1, 2, 3]
+        assert none_field.default is None

--- a/python/tests/test_input_functional.py
+++ b/python/tests/test_input_functional.py
@@ -1,0 +1,405 @@
+"""Functional tests for Input() with real predictors and schema generation."""
+
+from typing import List, Optional
+
+import pytest
+
+from coglet import inspector, schemas
+from coglet.api import BasePredictor, FieldInfo, Input
+
+
+class TestInputWithPredictors:
+    """Test Input() function with real predictor classes."""
+
+    def test_basic_predictor_with_input(self):
+        """Test predictor with basic Input() fields."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                message: str = Input(description='Message to process'),
+                count: int = Input(default=1, description='Number of times to repeat'),
+            ) -> str:
+                return message * count
+
+        # Test that predictor can be inspected
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Check inputs were processed correctly
+        assert len(pred.inputs) == 2
+        assert 'message' in pred.inputs
+        assert 'count' in pred.inputs
+
+        # Check message field
+        message_input = pred.inputs['message']
+        assert message_input.description == 'Message to process'
+        assert message_input.default is None
+
+        # Check count field
+        count_input = pred.inputs['count']
+        assert count_input.description == 'Number of times to repeat'
+        assert count_input.default == 1
+
+    def test_predictor_with_constraints(self):
+        """Test predictor with Input() validation constraints."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                temperature: float = Input(
+                    default=0.7,
+                    description='Temperature for generation',
+                    ge=0.0,
+                    le=2.0,
+                ),
+                max_tokens: int = Input(
+                    default=100, description='Maximum tokens to generate', ge=1, le=2000
+                ),
+                prompt: str = Input(
+                    description='Input prompt', min_length=1, max_length=1000
+                ),
+            ) -> str:
+                return f"Generated with temp={temperature}, max_tokens={max_tokens}, prompt='{prompt}'"
+
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Check temperature constraints
+        temp_input = pred.inputs['temperature']
+        assert temp_input.ge == 0.0
+        assert temp_input.le == 2.0
+        assert temp_input.default == 0.7
+
+        # Check max_tokens constraints
+        tokens_input = pred.inputs['max_tokens']
+        assert tokens_input.ge == 1
+        assert tokens_input.le == 2000
+        assert tokens_input.default == 100
+
+        # Check prompt constraints
+        prompt_input = pred.inputs['prompt']
+        assert prompt_input.min_length == 1
+        assert prompt_input.max_length == 1000
+        assert prompt_input.default is None
+
+    def test_predictor_with_choices(self):
+        """Test predictor with Input() choices constraint."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                model: str = Input(
+                    default='gpt-3.5-turbo',
+                    description='Model to use',
+                    choices=['gpt-3.5-turbo', 'gpt-4', 'claude-3'],
+                ),
+                format: str = Input(
+                    description='Output format', choices=['json', 'text', 'markdown']
+                ),
+            ) -> str:
+                return f'Using {model} with {format} format'
+
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Check model choices
+        model_input = pred.inputs['model']
+        assert model_input.choices == ['gpt-3.5-turbo', 'gpt-4', 'claude-3']
+        assert model_input.default == 'gpt-3.5-turbo'
+
+        # Check format choices
+        format_input = pred.inputs['format']
+        assert format_input.choices == ['json', 'text', 'markdown']
+        assert format_input.default is None
+
+    def test_predictor_with_optional_types(self):
+        """Test predictor with Optional type annotations."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                required_input: str = Input(description='Required field'),
+                optional_input: Optional[str] = Input(description='Optional field'),
+                optional_with_default: Optional[str] = Input(
+                    default='default_value', description='Optional with default'
+                ),
+            ) -> str:
+                return f'Required: {required_input}, Optional: {optional_input}, Default: {optional_with_default}'
+
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Check required input
+        required = pred.inputs['required_input']
+        assert required.default is None
+        assert required.description == 'Required field'
+
+        # Check optional input
+        optional = pred.inputs['optional_input']
+        assert optional.default is None
+        assert optional.description == 'Optional field'
+
+        # Check optional with default
+        optional_default = pred.inputs['optional_with_default']
+        assert optional_default.default == 'default_value'
+        assert optional_default.description == 'Optional with default'
+
+    def test_predictor_with_list_types(self):
+        """Test predictor with List type annotations."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                tags: List[str] = Input(
+                    default=['default'], description='List of tags'
+                ),
+                numbers: List[int] = Input(description='List of numbers'),
+            ) -> str:
+                return f'Tags: {tags}, Numbers: {numbers}'
+
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Check tags list
+        tags_input = pred.inputs['tags']
+        assert tags_input.default == ['default']
+        assert tags_input.description == 'List of tags'
+
+        # Check numbers list
+        numbers_input = pred.inputs['numbers']
+        assert numbers_input.default is None
+        assert numbers_input.description == 'List of numbers'
+
+
+class TestSchemaGeneration:
+    """Test JSON schema generation with Input() fields."""
+
+    def test_schema_generation_with_input(self):
+        """Test that JSON schema is generated correctly from Input() fields."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                text: str = Input(
+                    description='Input text to process', min_length=1, max_length=1000
+                ),
+                temperature: float = Input(
+                    default=0.7, description='Temperature parameter', ge=0.0, le=2.0
+                ),
+                model: str = Input(
+                    default='base',
+                    description='Model to use',
+                    choices=['base', 'large', 'xl'],
+                ),
+                deprecated_field: str = Input(
+                    default='old_value',
+                    description='This field is deprecated',
+                    deprecated=True,
+                ),
+            ) -> str:
+                return 'processed'
+
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Generate JSON schema
+        schema = schemas.to_json_schema(pred)
+
+        # Check overall structure
+        assert 'openapi' in schema
+        assert 'components' in schema
+        assert 'schemas' in schema['components']
+        assert 'Input' in schema['components']['schemas']
+
+        input_schema = schema['components']['schemas']['Input']
+        assert input_schema['type'] == 'object'
+        assert 'properties' in input_schema
+
+        # Check text field schema
+        text_prop = input_schema['properties']['text']
+        assert text_prop['type'] == 'string'
+        assert text_prop['title'] == 'Text'
+        assert text_prop['description'] == 'Input text to process'
+        assert text_prop['minLength'] == 1
+        assert text_prop['maxLength'] == 1000
+
+        # Check temperature field schema
+        temp_prop = input_schema['properties']['temperature']
+        assert temp_prop['type'] == 'number'
+        assert temp_prop['title'] == 'Temperature'
+        assert temp_prop['description'] == 'Temperature parameter'
+        assert temp_prop['minimum'] == 0.0
+        assert temp_prop['maximum'] == 2.0
+        assert temp_prop['default'] == 0.7
+
+        # Check model field schema (choices create separate enum schema)
+        model_prop = input_schema['properties']['model']
+        assert model_prop['default'] == 'base'
+        # For choices fields, the enum is in a separate schema referenced by allOf
+        if 'allOf' in model_prop:
+            assert '$ref' in model_prop['allOf'][0]
+            # The actual enum schema should be in the components
+            assert 'model' in schema['components']['schemas']
+            model_enum_schema = schema['components']['schemas']['model']
+            assert model_enum_schema['enum'] == ['base', 'large', 'xl']
+
+        # Check deprecated field
+        deprecated_prop = input_schema['properties']['deprecated_field']
+        assert deprecated_prop['deprecated'] is True
+        assert deprecated_prop['description'] == 'This field is deprecated'
+        assert deprecated_prop['default'] == 'old_value'
+
+        # Check required fields
+        assert 'text' in input_schema['required']
+        assert 'temperature' not in input_schema['required']  # has default
+        assert 'model' not in input_schema['required']  # has default
+        assert 'deprecated_field' not in input_schema['required']  # has default
+
+
+class TestInputValidation:
+    """Test input validation with Input() constraints."""
+
+    def test_validation_with_constraints(self):
+        """Test that input validation works with Input() constraints."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                score: int = Input(ge=0, le=100),
+                name: str = Input(min_length=2, max_length=50),
+                category: str = Input(choices=['A', 'B', 'C']),
+            ) -> str:
+                return f'Score: {score}, Name: {name}, Category: {category}'
+
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Test valid inputs
+        valid_inputs = {'score': 85, 'name': 'John', 'category': 'A'}
+        result = inspector.check_input(pred.inputs, valid_inputs)
+        assert result['score'] == 85
+        assert result['name'] == 'John'
+        assert result['category'] == 'A'
+
+        # Test invalid score (too high)
+        with pytest.raises(AssertionError, match='fails constraint <= 100'):
+            inspector.check_input(
+                pred.inputs, {'score': 150, 'name': 'John', 'category': 'A'}
+            )
+
+        # Test invalid score (too low)
+        with pytest.raises(AssertionError, match='fails constraint >= 0'):
+            inspector.check_input(
+                pred.inputs, {'score': -5, 'name': 'John', 'category': 'A'}
+            )
+
+        # Test invalid name (too short)
+        with pytest.raises(AssertionError, match='fails constraint len\\(\\) >= 2'):
+            inspector.check_input(
+                pred.inputs, {'score': 85, 'name': 'J', 'category': 'A'}
+            )
+
+        # Test invalid name (too long)
+        long_name = 'J' * 51
+        with pytest.raises(AssertionError, match='fails constraint len\\(\\) <= 50'):
+            inspector.check_input(
+                pred.inputs, {'score': 85, 'name': long_name, 'category': 'A'}
+            )
+
+        # Test invalid category (not in choices)
+        with pytest.raises(AssertionError, match='does not match choices'):
+            inspector.check_input(
+                pred.inputs, {'score': 85, 'name': 'John', 'category': 'D'}
+            )
+
+    def test_validation_with_regex(self):
+        """Test input validation with regex constraints."""
+
+        class TestPredictor(BasePredictor):
+            def predict(
+                self,
+                email: str = Input(
+                    regex=r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+                ),
+                phone: str = Input(regex=r'^\d{3}-\d{3}-\d{4}$'),
+            ) -> str:
+                return f'Email: {email}, Phone: {phone}'
+
+        pred = inspector._predictor_adt(
+            'test_module', 'TestPredictor', TestPredictor.predict, 'predict', True
+        )
+
+        # Test valid inputs
+        valid_inputs = {'email': 'test@example.com', 'phone': '555-123-4567'}
+        result = inspector.check_input(pred.inputs, valid_inputs)
+        assert result['email'] == 'test@example.com'
+        assert result['phone'] == '555-123-4567'
+
+        # Test invalid email
+        with pytest.raises(AssertionError, match='does not match regex'):
+            inspector.check_input(
+                pred.inputs, {'email': 'invalid-email', 'phone': '555-123-4567'}
+            )
+
+        # Test invalid phone
+        with pytest.raises(AssertionError, match='does not match regex'):
+            inspector.check_input(
+                pred.inputs, {'email': 'test@example.com', 'phone': '555-1234567'}
+            )
+
+
+class TestBackwardCompatibility:
+    """Test that Input() is backward compatible with existing code."""
+
+    def test_import_compatibility(self):
+        """Test that Input can still be imported the same way."""
+        from cog import Input as CogInput
+        from coglet.api import Input
+
+        # Both should work and be the same function
+        assert Input is CogInput
+
+        # Test they both return InputSpec instances
+        spec1 = Input(description='test')
+        spec2 = CogInput(description='test')
+
+        assert isinstance(spec1, FieldInfo)
+        assert isinstance(spec2, FieldInfo)
+        assert spec1.description == spec2.description
+
+    def test_existing_predictor_patterns(self):
+        """Test that existing predictor patterns still work."""
+
+        # This mimics existing test patterns from the codebase
+        class Predictor(BasePredictor):
+            def predict(
+                self,
+                b: bool = Input(default=False),
+                f: float = Input(default=0.0),
+                i: int = Input(default=0),
+                s: str = Input(default='foo'),
+            ) -> str:
+                return f'{b},{f:.2f},{i},{s}'
+
+        # Test inspection works
+        pred = inspector._predictor_adt(
+            'test', 'Predictor', Predictor.predict, 'predict', True
+        )
+
+        # Test defaults are preserved
+        assert pred.inputs['b'].default is False
+        assert pred.inputs['f'].default == 0.0
+        assert pred.inputs['i'].default == 0
+        assert pred.inputs['s'].default == 'foo'
+
+        # Test validation works with defaults
+        result = inspector.check_input(pred.inputs, {})
+        assert result == {'b': False, 'f': 0.0, 'i': 0, 's': 'foo'}


### PR DESCRIPTION
Convert Input from dataclass to function with overloads following Pydantic's pattern. Maintains exact same syntax for developers while providing full type checker compatibility.

Key changes:
- Add Input() function with @overload decorators returning Any for type checkers
- Create FieldInfo dataclass to store field metadata at runtime
- Update inspector.py to use FieldInfo instead of Input dataclass
- Add comprehensive test suite (31 unit/functional tests + Go integration)
- Fix BaseModel inheritance tests with proper type annotations and getattr usage