### PR TITLE
Update argument type check to use ast.Constant

### DIFF
--- a/python/cog/command/call_graph.py
+++ b/python/cog/command/call_graph.py
@@ -65,7 +65,7 @@ class IncludeAnalyzer(ast.NodeVisitor):
                 )
             elif node.args:
                 arg = node.args[0]
-                if isinstance(arg, ast.Str):
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
                     self.includes.append(arg.s)
                 else:
                     raise ValueError(


### PR DESCRIPTION
This fixes a deprecation warning that `ast.Str` will be removed in Python 14.