### PR TITLE
Remove `experimental internal function` warning

### DIFF
--- a/python/coglet/scope.py
+++ b/python/coglet/scope.py
@@ -1,10 +1,7 @@
 import contextvars
 import sys
-import warnings
 from collections import defaultdict
 from typing import Any, Callable, Dict, Optional
-
-from coglet import api
 
 ctx_pid: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     'pid', default=None
@@ -33,11 +30,6 @@ class Scope:
 # Compat: for internal model metrics
 # https://github.com/replicate/cog/blob/main/python/cog/server/scope.py
 def current_scope() -> Scope:
-    warnings.warn(
-        'current_scope is an experimental internal function. It may change or be removed without warning.',
-        category=api.ExperimentalFeatureWarning,
-        stacklevel=1,
-    )
     pid = ctx_pid.get()
     assert pid is not None
     return Scope(pid)


### PR DESCRIPTION
An `experimental internal function` warning is being printed to user-facing logs due to coglet code's use of `current_scope`. We don't want to hurt the ux with confusing/alarming in-actionable warnings, so let's drop it.

<img width="493" height="77" alt="image" src="https://github.com/user-attachments/assets/d4967a4c-8586-430b-8e0b-272408cdad82" />
