### PR TITLE
bugfix: Ensure schema is loaded before processing

### DIFF
--- a/internal/runner/manager.go
+++ b/internal/runner/manager.go
@@ -219,7 +219,7 @@ func (m *Manager) predict(ctx context.Context, req PredictionRequest, async bool
 		// the OpenAPI schema is available for input processing
 		log.Tracew("runner setup complete, proceeding with prediction", "prediction_id", req.ID, "runner", runner.runnerCtx.id)
 	case <-pending.ctx.Done():
-		// Prediction was canceled, watcher will perform cleanup, er need to abort
+		// Prediction was canceled, watcher will perform cleanup, we need to abort
 		// the rest of the prediction processing
 		log.Tracew("prediction was canceled before setup complete, aborting", "prediction_id", req.ID, "runner", runner.runnerCtx.id)
 		m.releaseSlot()

--- a/internal/runner/path_test.go
+++ b/internal/runner/path_test.go
@@ -576,7 +576,7 @@ func TestProcessInputPaths(t *testing.T) {
 		}
 
 		result, err := ProcessInputPaths(input, nil, &paths, mockFn)
-		require.NoError(t, err)
+		require.ErrorIs(t, err, ErrSchemaNotAvailable)
 		assert.Equal(t, input, result)
 		assert.Empty(t, paths)
 	})

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -853,7 +853,7 @@ func (r *Runner) predict(reqID string) (chan PredictionResponse, *PredictionResp
 	}
 	pending.inputPaths = inputPaths
 
-	// Write prediction request to file (async like original)[]
+	// Write prediction request to file
 	requestFile := fmt.Sprintf("request-%s.json", reqID)
 	log.Debugw("writing prediction request file", "prediction_id", reqID, "file", requestFile)
 	requestPath := path.Join(r.runnerCtx.workingdir, requestFile)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -812,28 +812,35 @@ func (r *Runner) verifyProcessCleanup(pid int) {
 
 // predict returns a channel that will receive the prediction response and an initial prediction response
 // populated with the relevant fields from the request
-func (r *Runner) predict(req PredictionRequest) (chan PredictionResponse, *PredictionResponse, error) {
+func (r *Runner) predict(reqID string) (chan PredictionResponse, *PredictionResponse, error) {
 	log := r.logger.Sugar()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	log.Tracew("runner.predict called", "prediction_id", req.ID, "status", r.status)
+	log.Tracew("runner.predict called", "prediction_id", reqID, "status", r.status)
 
 	// Prediction must be pre-allocated by manager
-	pending, exists := r.pending[req.ID]
+	pending, exists := r.pending[reqID]
 	if !exists {
-		return nil, nil, fmt.Errorf("prediction %s not allocated", req.ID)
+		return nil, nil, fmt.Errorf("prediction %s not allocated", reqID)
 	}
 
-	log.Tracew("prediction found in pending", "prediction_id", req.ID)
+	if pending.request.ID != reqID {
+		return nil, nil, fmt.Errorf("prediction ID mismatch: expected %s, got %s", reqID, pending.request.ID)
+	}
+
+	pending.mu.Lock()
+	defer pending.mu.Unlock()
+
+	log.Tracew("prediction found in pending", "prediction_id", reqID)
 
 	// Process input paths (base64 and URL inputs)
 	inputPaths := make([]string, 0)
 	if r.doc == nil {
-		log.Errorw("OpenAPI schema not available for input processing - cannot convert base64 or URL inputs", "prediction_id", req.ID)
+		log.Errorw("OpenAPI schema not available for input processing - cannot convert base64 or URL inputs", "prediction_id", reqID)
 	} else {
 		// Process base64 inputs first, then URL inputs (to allow URL inputs to reference base64-decoded files)
-		input, err := ProcessInputPaths(req.Input, r.doc, &inputPaths, Base64ToInput)
+		input, err := ProcessInputPaths(pending.request.Input, r.doc, &inputPaths, Base64ToInput)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process base64 inputs: %w", err)
 		}
@@ -842,16 +849,16 @@ func (r *Runner) predict(req PredictionRequest) (chan PredictionResponse, *Predi
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to process URL inputs: %w", err)
 		}
-		req.Input = input
+		pending.request.Input = input
 	}
 	pending.inputPaths = inputPaths
 
 	// Write prediction request to file (async like original)[]
-	requestFile := fmt.Sprintf("request-%s.json", req.ID)
-	log.Debugw("writing prediction request file", "prediction_id", req.ID, "file", requestFile)
+	requestFile := fmt.Sprintf("request-%s.json", reqID)
+	log.Debugw("writing prediction request file", "prediction_id", reqID, "file", requestFile)
 	requestPath := path.Join(r.runnerCtx.workingdir, requestFile)
 
-	requestData, err := json.Marshal(req)
+	requestData, err := json.Marshal(pending.request)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
@@ -860,13 +867,13 @@ func (r *Runner) predict(req PredictionRequest) (chan PredictionResponse, *Predi
 		return nil, nil, fmt.Errorf("failed to write request file: %w", err)
 	}
 
-	log.Tracew("wrote prediction request file", "prediction_id", req.ID, "path", requestPath, "working_dir", r.runnerCtx.workingdir, "request_data", string(requestData))
+	log.Tracew("wrote prediction request file", "prediction_id", reqID, "path", requestPath, "working_dir", r.runnerCtx.workingdir, "request_data", string(requestData))
 
 	// Debug: Check if file actually exists and list directory contents
 	if _, err := os.Stat(requestPath); err != nil {
-		log.Tracew("ERROR: written request file does not exist", "prediction_id", req.ID, "path", requestPath, "error", err)
+		log.Tracew("ERROR: written request file does not exist", "prediction_id", reqID, "path", requestPath, "error", err)
 	} else {
-		log.Tracew("confirmed request file exists", "prediction_id", req.ID, "path", requestPath)
+		log.Tracew("confirmed request file exists", "prediction_id", reqID, "path", requestPath)
 	}
 
 	// Debug: List all files in working directory
@@ -875,25 +882,14 @@ func (r *Runner) predict(req PredictionRequest) (chan PredictionResponse, *Predi
 		for i, entry := range entries {
 			fileNames[i] = entry.Name()
 		}
-		log.Tracew("working directory contents after write", "prediction_id", req.ID, "working_dir", r.runnerCtx.workingdir, "files", fileNames)
+		log.Tracew("working directory contents after write", "prediction_id", reqID, "working_dir", r.runnerCtx.workingdir, "files", fileNames)
 	}
 
-	// Update pending prediction with request details
-	pending.request = req
-
-	now := time.Now().Format(config.TimeFormat)
-	if pending.request.CreatedAt == "" {
-		pending.request.CreatedAt = now
-	}
-	if pending.request.StartedAt == "" {
-		pending.request.StartedAt = now
-	}
-
-	log.Tracew("returning prediction channel", "prediction_id", req.ID)
+	log.Tracew("returning prediction channel", "prediction_id", reqID)
 	initialResponse := &PredictionResponse{
 		Status: PredictionStarting,
 	}
-	initialResponse.populateFromRequest(req)
+	initialResponse.populateFromRequest(pending.request)
 	return pending.c, initialResponse, nil
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/replicate/cog-runtime/internal/config"
 	"github.com/replicate/cog-runtime/internal/webhook"
+	"github.com/replicate/go/uuid"
 )
 
 // LogsSlice is a []string that marshals to/from a newline-joined string in JSON
@@ -411,4 +412,17 @@ type MetricsPayload struct {
 	Source string         `json:"source,omitempty"`
 	Type   string         `json:"type,omitempty"`
 	Data   map[string]any `json:"data,omitempty"`
+}
+
+func PredictionID() (string, error) {
+	u, err := uuid.NewV7()
+	if err != nil {
+		return "", err
+	}
+	shuffle := make([]byte, uuid.Size)
+	for i := 0; i < 4; i++ {
+		shuffle[i], shuffle[i+4], shuffle[i+8], shuffle[i+12] = u[i+12], u[i+4], u[i], u[i+8]
+	}
+	encoding := base32.NewEncoding("0123456789abcdefghjkmnpqrstvwxyz").WithPadding(base32.NoPadding)
+	return encoding.EncodeToString(shuffle), nil
 }

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -16,9 +16,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/replicate/go/uuid"
+
 	"github.com/replicate/cog-runtime/internal/config"
 	"github.com/replicate/cog-runtime/internal/webhook"
-	"github.com/replicate/go/uuid"
 )
 
 // LogsSlice is a []string that marshals to/from a newline-joined string in JSON

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -337,6 +337,7 @@ type PendingPrediction struct {
 
 	// Per-prediction watcher cancellation and notification
 	cancel       context.CancelFunc
+	ctx          context.Context //nolint:containedctx // context for the lifetime of the prediction, used in runner.predict as well as the watcher
 	watcherDone  chan struct{}
 	outputNotify chan struct{} // Receives OUTPUT IPC events for this prediction
 

--- a/internal/tests/async_prediction_test.go
+++ b/internal/tests/async_prediction_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
-	"github.com/replicate/cog-runtime/internal/server"
 	"github.com/replicate/cog-runtime/internal/webhook"
 )
 
@@ -62,7 +61,7 @@ func TestAsyncPrediction(t *testing.T) {
 			})
 			waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
 
-			predictionID, err := server.PredictionID()
+			predictionID, err := runner.PredictionID()
 			require.NoError(t, err)
 			prediction := runner.PredictionRequest{
 				Input:   map[string]any{"i": 1, "s": "bar"},
@@ -118,7 +117,7 @@ func TestAsyncPredictionCanceled(t *testing.T) {
 	})
 	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
 
-	predictionID, err := server.PredictionID()
+	predictionID, err := runner.PredictionID()
 	require.NoError(t, err)
 	prediction := runner.PredictionRequest{
 		Input:   map[string]any{"i": 60, "s": "bar"},
@@ -195,7 +194,7 @@ func TestAsyncPredictionConcurrency(t *testing.T) {
 	assert.Equal(t, 1, hc.Concurrency.Max)
 	assert.Equal(t, 0, hc.Concurrency.Current)
 
-	predictionID, err := server.PredictionID()
+	predictionID, err := runner.PredictionID()
 	require.NoError(t, err)
 	prediction := runner.PredictionRequest{
 		Input:   map[string]any{"i": 1, "s": "bar"},

--- a/internal/tests/async_predictor_test.go
+++ b/internal/tests/async_predictor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
-	"github.com/replicate/cog-runtime/internal/server"
 	"github.com/replicate/cog-runtime/internal/webhook"
 )
 
@@ -28,9 +27,9 @@ func TestAsyncPredictorConcurrency(t *testing.T) {
 	receiverServer := testHarnessReceiverServer(t)
 	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
 
-	barID, err := server.PredictionID()
+	barID, err := runner.PredictionID()
 	require.NoError(t, err)
-	bazID, err := server.PredictionID()
+	bazID, err := runner.PredictionID()
 	require.NoError(t, err)
 	barReq := httpPredictionRequestWithID(t, runtimeServer, runner.PredictionRequest{
 		Input:               map[string]any{"i": 1, "s": "bar"},
@@ -94,7 +93,7 @@ func TestAsyncPredictorCanceled(t *testing.T) {
 	receiverServer := testHarnessReceiverServer(t)
 	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
 
-	barID, err := server.PredictionID()
+	barID, err := runner.PredictionID()
 	require.NoError(t, err)
 	barReq := httpPredictionRequestWithID(t, runtimeServer, runner.PredictionRequest{
 		Input:   map[string]any{"i": 60, "s": "bar"},

--- a/internal/tests/filter_test.go
+++ b/internal/tests/filter_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
-	"github.com/replicate/cog-runtime/internal/server"
 	"github.com/replicate/cog-runtime/internal/webhook"
 )
 
@@ -104,7 +103,7 @@ func TestPredictionWebhookFilter(t *testing.T) {
 			})
 			waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
 
-			predictionID, err := server.PredictionID()
+			predictionID, err := runner.PredictionID()
 			require.NoError(t, err)
 			prediction := runner.PredictionRequest{
 				Input:               map[string]any{"i": 2, "s": "bar"},

--- a/internal/tests/iterator_test.go
+++ b/internal/tests/iterator_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
-	"github.com/replicate/cog-runtime/internal/server"
 	"github.com/replicate/cog-runtime/internal/webhook"
 )
 
@@ -92,9 +91,9 @@ func TestPredictionAsyncIteratorConcurrency(t *testing.T) {
 
 	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
 
-	barID, err := server.PredictionID()
+	barID, err := runner.PredictionID()
 	require.NoError(t, err)
-	bazID, err := server.PredictionID()
+	bazID, err := runner.PredictionID()
 	require.NoError(t, err)
 	barPrediction := runner.PredictionRequest{
 		Input:               map[string]any{"i": 1, "s": "bar"},

--- a/internal/tests/path_input_regression_test.go
+++ b/internal/tests/path_input_regression_test.go
@@ -1,0 +1,212 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog-runtime/internal/runner"
+	"github.com/replicate/cog-runtime/internal/webhook"
+)
+
+// TestPathInputHTTPSRegression tests that HTTPS URLs are properly downloaded
+// and converted to local paths across all runtime modes. This prevents regression
+// of the issue where schema loading timing caused URLs to be passed unchanged.
+func TestPathInputHTTPSRegression(t *testing.T) {
+	// Create a test server that serves dummy image data
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("fake-jpeg-data-for-testing"))
+	}))
+	t.Cleanup(testServer.Close)
+
+	testCases := []struct {
+		name          string
+		procedureMode bool
+		useWebhook    bool
+	}{
+		{"procedure-mode-no-webhook", true, false},
+		{"procedure-mode-with-webhook", true, true},
+		{"non-procedure-mode-no-webhook", false, false},
+		{"non-procedure-mode-with-webhook", false, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if *legacyCog && tc.procedureMode {
+				t.Skip("procedure endpoint has diverged from legacy Cog")
+			}
+
+			var receiverServer *testHarnessReceiver
+			if tc.useWebhook {
+				receiverServer = testHarnessReceiverServer(t)
+			}
+
+			// Setup runtime server
+			if tc.procedureMode {
+				testProcedureModeHTTPSProcessing(t, testServer, receiverServer)
+			} else {
+				testNonProcedureModeHTTPSProcessing(t, testServer, receiverServer)
+			}
+		})
+	}
+}
+
+func testProcedureModeHTTPSProcessing(t *testing.T, testServer *httptest.Server, receiverServer *testHarnessReceiver) {
+	runtimeServer, _, _ := setupCogRuntimeServer(t, cogRuntimeServerConfig{
+		procedureMode:    true,
+		explicitShutdown: true,
+		uploadURL:        "",
+		maxRunners:       1,
+	})
+
+	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
+
+	procedureURL := fmt.Sprintf("file://%s/python/tests/procedures/path_test", basePath)
+
+	prediction := runner.PredictionRequest{
+		Input: map[string]any{
+			"img": testServer.URL + "/test-image.jpg",
+		},
+		Context: map[string]any{
+			"procedure_source_url": procedureURL,
+			"replicate_api_token":  "test-token",
+		},
+	}
+
+	if receiverServer != nil {
+		prediction.Webhook = receiverServer.URL + "/webhook"
+		prediction.WebhookEventsFilter = []webhook.Event{webhook.EventCompleted}
+
+		predictionID, statusCode := runProcedure(t, runtimeServer, prediction)
+		require.Equal(t, http.StatusAccepted, statusCode)
+
+		// Wait for webhook completion
+		var wh webhookData
+		select {
+		case wh = <-receiverServer.webhookReceiverChan:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timeout waiting for webhook")
+		}
+
+		assert.Equal(t, runner.PredictionSucceeded, wh.Response.Status)
+		assert.Equal(t, predictionID, wh.Response.ID)
+
+		// Key assertion: URL should be processed into base64 data URL
+		output, ok := wh.Response.Output.(string)
+		require.True(t, ok, "output should be a string")
+		assert.True(t, strings.HasPrefix(output, "data:"),
+			"HTTPS URL should be downloaded and converted to base64 data URL, got: %s", output)
+		assert.NotEqual(t, testServer.URL+"/test-image.jpg", output,
+			"output should not be the original HTTPS URL - this means URL processing failed")
+	} else {
+		// For procedure mode without webhook, make direct HTTP request
+		req := httpPredictionRequest(t, runtimeServer, prediction)
+		req.URL.Path = "/procedures"
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Should get synchronous response with the result
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var predictionResponse runner.PredictionResponse
+		err = json.Unmarshal(body, &predictionResponse)
+		require.NoError(t, err)
+
+		assert.Equal(t, runner.PredictionSucceeded, predictionResponse.Status)
+
+		// Key assertion: URL should be processed into base64 data URL
+		output, ok := predictionResponse.Output.(string)
+		require.True(t, ok, "output should be a string")
+		assert.True(t, strings.HasPrefix(output, "data:"),
+			"HTTPS URL should be downloaded and converted to base64 data URL, got: %s", output)
+		assert.NotEqual(t, testServer.URL+"/test-image.jpg", output,
+			"output should not be the original HTTPS URL - this means URL processing failed")
+	}
+}
+
+func testNonProcedureModeHTTPSProcessing(t *testing.T, testServer *httptest.Server, receiverServer *testHarnessReceiver) {
+	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
+		procedureMode:    false,
+		explicitShutdown: true,
+		uploadURL:        "",
+		module:           "path_input_https",
+		predictorClass:   "Predictor",
+	})
+	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
+
+	prediction := runner.PredictionRequest{
+		Input: map[string]any{
+			"img": testServer.URL + "/test-image.jpg",
+		},
+	}
+
+	if receiverServer != nil {
+		prediction.Webhook = receiverServer.URL + "/webhook"
+		prediction.WebhookEventsFilter = []webhook.Event{webhook.EventCompleted}
+	}
+
+	if receiverServer != nil {
+		// Async mode with webhook
+		req := httpPredictionRequest(t, runtimeServer, prediction)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+		// Wait for webhook completion
+		var wh webhookData
+		select {
+		case wh = <-receiverServer.webhookReceiverChan:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timeout waiting for webhook")
+		}
+
+		assert.Equal(t, runner.PredictionSucceeded, wh.Response.Status)
+
+		// Key assertion: URL should be processed into base64 data URL
+		output, ok := wh.Response.Output.(string)
+		require.True(t, ok, "output should be a string")
+		assert.True(t, strings.HasPrefix(output, "data:"),
+			"HTTPS URL should be downloaded and converted to base64 data URL, got: %s", output)
+		assert.NotEqual(t, testServer.URL+"/test-image.jpg", output,
+			"output should not be the original HTTPS URL - this means URL processing failed")
+	} else {
+		// Synchronous mode without webhook
+		req := httpPredictionRequest(t, runtimeServer, prediction)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var predictionResponse testHarnessResponse
+		err = json.Unmarshal(body, &predictionResponse)
+		require.NoError(t, err)
+
+		assert.Equal(t, runner.PredictionSucceeded, predictionResponse.Status)
+
+		// Key assertion: URL should be processed into base64 data URL
+		output, ok := predictionResponse.Output.(string)
+		require.True(t, ok, "output should be a string")
+		assert.True(t, strings.HasPrefix(output, "data:"),
+			"HTTPS URL should be downloaded and converted to base64 data URL, got: %s", output)
+		assert.NotEqual(t, testServer.URL+"/test-image.jpg", output,
+			"output should not be the original HTTPS URL - this means URL processing failed")
+	}
+}

--- a/internal/tests/path_input_regression_test.go
+++ b/internal/tests/path_input_regression_test.go
@@ -62,6 +62,7 @@ func TestPathInputHTTPSRegression(t *testing.T) {
 }
 
 func testProcedureModeHTTPSProcessing(t *testing.T, testServer *httptest.Server, receiverServer *testHarnessReceiver) {
+	t.Helper()
 	runtimeServer, _, _ := setupCogRuntimeServer(t, cogRuntimeServerConfig{
 		procedureMode:    true,
 		explicitShutdown: true,
@@ -138,6 +139,7 @@ func testProcedureModeHTTPSProcessing(t *testing.T, testServer *httptest.Server,
 }
 
 func testNonProcedureModeHTTPSProcessing(t *testing.T, testServer *httptest.Server, receiverServer *testHarnessReceiver) {
+	t.Helper()
 	runtimeServer := setupCogRuntime(t, cogRuntimeServerConfig{
 		procedureMode:    false,
 		explicitShutdown: true,

--- a/internal/tests/path_input_regression_test.go
+++ b/internal/tests/path_input_regression_test.go
@@ -21,6 +21,10 @@ import (
 // and converted to local paths across all runtime modes. This prevents regression
 // of the issue where schema loading timing caused URLs to be passed unchanged.
 func TestPathInputHTTPSRegression(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("this test is validating the cog-runtime server's behavior not legacy cog")
+	}
 	// Create a test server that serves dummy image data
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")

--- a/internal/tests/path_test.go
+++ b/internal/tests/path_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
-	"github.com/replicate/cog-runtime/internal/server"
 	"github.com/replicate/cog-runtime/internal/webhook"
 )
 
@@ -339,13 +338,13 @@ func TestPredictionPathMimeTypes(t *testing.T) {
 
 	testDataPrefix := contentServer.URL + "/mimetype/"
 
-	gifPredictionID, err := server.PredictionID()
+	gifPredictionID, err := runner.PredictionID()
 	require.NoError(t, err)
-	jarPredictionID, err := server.PredictionID()
+	jarPredictionID, err := runner.PredictionID()
 	require.NoError(t, err)
-	tarPredictionID, err := server.PredictionID()
+	tarPredictionID, err := runner.PredictionID()
 	require.NoError(t, err)
-	webpPredictionID, err := server.PredictionID()
+	webpPredictionID, err := runner.PredictionID()
 	require.NoError(t, err)
 
 	predictions := []struct {

--- a/internal/tests/prediction_test.go
+++ b/internal/tests/prediction_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
-	"github.com/replicate/cog-runtime/internal/server"
 	"github.com/replicate/cog-runtime/internal/webhook"
 )
 
@@ -61,7 +60,7 @@ func TestPredictionWithIdSucceeded(t *testing.T) {
 	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
 
 	input := map[string]any{"i": 1, "s": "bar"}
-	predictionID, err := server.PredictionID()
+	predictionID, err := runner.PredictionID()
 	require.NoError(t, err)
 	predictionReq := runner.PredictionRequest{
 		ID:    predictionID,

--- a/internal/tests/procedure_schema_test.go
+++ b/internal/tests/procedure_schema_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
 	"github.com/replicate/cog-runtime/internal/webhook"
@@ -65,7 +64,7 @@ func TestProcedureSchemaLoadingSequential(t *testing.T) {
 			}
 
 			_, statusCode := runProcedure(t, runtimeServer, prediction)
-			require.Equal(t, http.StatusAccepted, statusCode)
+			assert.Equal(t, http.StatusAccepted, statusCode)
 
 			var wh webhookData
 			select {
@@ -79,7 +78,7 @@ func TestProcedureSchemaLoadingSequential(t *testing.T) {
 
 			// Verify URL processing worked - this is the key regression test
 			output, ok := wh.Response.Output.(string)
-			require.True(t, ok, "output should be a string for prediction %d", predIndex)
+			assert.True(t, ok, "output should be a string for prediction %d", predIndex)
 			assert.True(t, strings.HasPrefix(output, "data:"),
 				"prediction %d: HTTPS URL should be downloaded and converted to base64, got: %s", predIndex, output)
 		}(i)

--- a/internal/tests/procedure_schema_test.go
+++ b/internal/tests/procedure_schema_test.go
@@ -1,0 +1,91 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/replicate/cog-runtime/internal/runner"
+	"github.com/replicate/cog-runtime/internal/webhook"
+)
+
+// TestProcedureSchemaLoadingSequential tests that schema loading works correctly
+// for sequential predictions in procedure mode where runners may be cleaned up
+// between predictions. This is a specific regression test for the issue where
+// schema loading timing caused problems after runner recreation.
+func TestProcedureSchemaLoadingSequential(t *testing.T) {
+	t.Parallel()
+	if *legacyCog {
+		t.Skip("procedure endpoint has diverged from legacy Cog")
+	}
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("fake-jpeg-data-for-testing"))
+	}))
+	t.Cleanup(testServer.Close)
+
+	receiverServer := testHarnessReceiverServer(t)
+
+	runtimeServer, _, _ := setupCogRuntimeServer(t, cogRuntimeServerConfig{
+		procedureMode:    true,
+		explicitShutdown: true,
+		uploadURL:        "",
+		maxRunners:       1, // Force runner recreation between predictions
+	})
+
+	waitForSetupComplete(t, runtimeServer, runner.StatusReady, runner.SetupSucceeded)
+	procedureURL := fmt.Sprintf("file://%s/python/tests/procedures/path_test", basePath)
+
+	wg := sync.WaitGroup{}
+
+	// Run 3 sequential predictions to test schema loading robustness
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(predIndex int) {
+			defer wg.Done()
+
+			prediction := runner.PredictionRequest{
+				Input: map[string]any{
+					"img": fmt.Sprintf("%s/image-%d.jpg", testServer.URL, predIndex),
+				},
+				Context: map[string]any{
+					"procedure_source_url": procedureURL,
+					"replicate_api_token":  "test-token",
+				},
+				Webhook:             receiverServer.URL + "/webhook",
+				WebhookEventsFilter: []webhook.Event{webhook.EventCompleted},
+			}
+
+			_, statusCode := runProcedure(t, runtimeServer, prediction)
+			require.Equal(t, http.StatusAccepted, statusCode)
+
+			var wh webhookData
+			select {
+			case wh = <-receiverServer.webhookReceiverChan:
+			case <-time.After(10 * time.Second):
+				t.Errorf("timeout waiting for webhook for prediction %d", predIndex)
+				return
+			}
+
+			assert.Equal(t, runner.PredictionSucceeded, wh.Response.Status, "prediction %d should succeed", predIndex)
+
+			// Verify URL processing worked - this is the key regression test
+			output, ok := wh.Response.Output.(string)
+			require.True(t, ok, "output should be a string for prediction %d", predIndex)
+			assert.True(t, strings.HasPrefix(output, "data:"),
+				"prediction %d: HTTPS URL should be downloaded and converted to base64, got: %s", predIndex, output)
+		}(i)
+
+		// Wait for this prediction to complete before starting the next
+		// This ensures sequential execution and potential runner cleanup between predictions
+		wg.Wait()
+	}
+}

--- a/internal/tests/shutdown_test.go
+++ b/internal/tests/shutdown_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/cog-runtime/internal/runner"
-	"github.com/replicate/cog-runtime/internal/server"
 	"github.com/replicate/cog-runtime/internal/webhook"
 )
 
@@ -83,7 +82,7 @@ func TestShutdownEndpointWaitsForInflightPredictions(t *testing.T) {
 	baseURL := httpTestServer.URL
 
 	// Start an async prediction
-	predictionID, err := server.PredictionID()
+	predictionID, err := runner.PredictionID()
 	require.NoError(t, err)
 
 	prediction := runner.PredictionRequest{
@@ -118,7 +117,7 @@ func TestShutdownEndpointWaitsForInflightPredictions(t *testing.T) {
 	assert.Equal(t, http.StatusOK, shutdownResp.StatusCode)
 
 	// Verify new predictions are rejected during shutdown with 503
-	newPredictionID, err := server.PredictionID()
+	newPredictionID, err := runner.PredictionID()
 	require.NoError(t, err)
 	newPrediction := runner.PredictionRequest{
 		Input:   map[string]any{"i": 1, "s": "should_be_rejected"},

--- a/python/tests/procedures/path_test/cog.yaml
+++ b/python/tests/procedures/path_test/cog.yaml
@@ -1,0 +1,3 @@
+predict: "predict.py:predict"
+concurrency:
+  max: 1

--- a/python/tests/procedures/path_test/predict.py
+++ b/python/tests/procedures/path_test/predict.py
@@ -1,0 +1,10 @@
+from cog import Input, Path
+
+
+def predict(
+    img: Path = Input(
+        description='Reference image of the character whose face to swap'
+    ),
+) -> Path:
+    print('img', type(img), img)
+    return img

--- a/python/tests/runners/path_input_https.py
+++ b/python/tests/runners/path_input_https.py
@@ -1,0 +1,14 @@
+from cog import BasePredictor, Input, Path
+
+
+class Predictor(BasePredictor):
+    """Test predictor that exactly matches the user's scenario with Path = Input(...)"""
+
+    def predict(
+        self,
+        img: Path = Input(
+            description='Reference image of the character whose face to swap'
+        ),
+    ) -> Path:
+        print('img', type(img), img)
+        return img

--- a/python/tests/runners/path_input_https.py
+++ b/python/tests/runners/path_input_https.py
@@ -12,3 +12,9 @@ class Predictor(BasePredictor):
     ) -> Path:
         print('img', type(img), img)
         return img
+
+    @property
+    def test_inputs(self):
+        return {
+            'img': 'https://httpbin.org/image/jpeg',
+        }


### PR DESCRIPTION
Schema wasn't loaded prior to processing the input paths this resulted in a noop nil response. To ensure we always load the schema first we now block on runner ready state before processing. Additionaly a nil doc is considered an error. In the cases we call ProcessInputPaths we can accept that error; in manager we explicitly check for doc being nil and emit an error log.